### PR TITLE
Feat/#23: 공지사항 크롤링

### DIFF
--- a/src/@types/college.ts
+++ b/src/@types/college.ts
@@ -1,0 +1,6 @@
+export interface College {
+  collegeName: string;
+  departmentName: string;
+  departmentSubName: string;
+  departmentLink: string;
+}

--- a/src/crawling/collegeCrawling.ts
+++ b/src/crawling/collegeCrawling.ts
@@ -1,12 +1,6 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
-
-interface College {
-  collegeName: string;
-  departmentName: string;
-  departmentSubName: string;
-  departmentLink: string;
-}
+import { College } from 'src/@types/college';
 
 export const collegeCrawling = async (): Promise<College[]> => {
   const collegeList: College[] = [];
@@ -27,7 +21,14 @@ export const collegeCrawling = async (): Promise<College[]> => {
               arr.push($(res).text().trim());
             } else arr.push($(res).find('a').attr('href'));
           });
-        if (arr[0] !== '학부대학' && arr[0] !== undefined) {
+        if (
+          arr[0] !== '학부대학' &&
+          arr[0] !== undefined &&
+          arr[0] !== '미래융합대학' &&
+          arr[2] !== '통계·데이터사이언스전공' &&
+          arr[3] !== undefined
+        ) {
+          if (arr[3].endsWith('/')) arr[3] = arr[3].slice(0, -1);
           const tmpList = {
             collegeName: arr[0],
             departmentName: arr[1],

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -52,3 +52,22 @@ export const noticeCrawling = async (college: College): Promise<string> => {
 
   return hostLink + findNoticeLink('공지사항(학부)', college, $);
 };
+
+export const noticeListCrawling = async (link: string): Promise<string[]> => {
+  const response = await axios.get(link);
+  const $ = cheerio.load(response.data);
+  let tableData = $('table').find('tbody').find('tr');
+  tableData = tableData.length > 0 ? tableData : $('ul#board_list').find('li');
+
+  if (tableData.length < 1) console.error('테이블이 없음..');
+  const contentLink: string[] = [];
+
+  tableData.each((index, element) => {
+    const anchorElement = $(element).find('a');
+    let tmpLink = anchorElement.attr('href');
+    if (tmpLink[0] === '?' || tmpLink[0] === '/') tmpLink = link + tmpLink;
+    contentLink.push(tmpLink);
+  });
+
+  return contentLink;
+};

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -1,0 +1,54 @@
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { College } from 'src/@types/college';
+
+interface Notice {
+  title: string;
+  path: string;
+  description: string;
+  data: string;
+}
+
+interface MajorNotice {
+  notice: Notice[];
+}
+
+const findNoticeLink = (
+  targetName: string,
+  college: College,
+  $: cheerio.CheerioAPI,
+): string => {
+  const selector = `:contains("${targetName}")`;
+  const targetElements = $(selector);
+  let noticeLink = '';
+  let flag = true;
+
+  targetElements.each((index, element) => {
+    const link = $(element).attr('href');
+    if (college.departmentName === '유아교육과' && flag) {
+      noticeLink = '/education/1553';
+      flag = false;
+    } else if (link !== undefined && link !== '#none' && flag) {
+      noticeLink = link;
+      flag = false;
+    }
+  });
+
+  return noticeLink;
+};
+
+export const noticeCrawling = async (college: College): Promise<string> => {
+  let protocol = 'https://';
+  if (college.departmentSubName === '의공학전공') {
+    protocol = 'http://';
+  } else if (college.departmentSubName === '공간정보시스템공학전공')
+    return 'http://geoinfo.pknu.ac.kr/05piazza/08.php';
+  const response = await axios.get(college.departmentLink);
+  const hostLink = protocol + response.request._redirectable._options.hostname;
+  const $ = cheerio.load(response.data);
+  const noticeLink = hostLink + findNoticeLink('공지사항', college, $);
+
+  if (noticeLink !== '') return noticeLink;
+
+  return hostLink + findNoticeLink('공지사항(학부)', college, $);
+};

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -55,6 +55,8 @@ export const noticeCrawling = async (college: College): Promise<string> => {
 
 export const noticeListCrawling = async (link: string): Promise<string[]> => {
   const response = await axios.get(link);
+  const hostLink =
+    'https://' + response.request._redirectable._options.hostname;
   const $ = cheerio.load(response.data);
   let tableData = $('table').find('tbody').find('tr');
   tableData = tableData.length > 0 ? tableData : $('ul#board_list').find('li');
@@ -65,7 +67,8 @@ export const noticeListCrawling = async (link: string): Promise<string[]> => {
   tableData.each((index, element) => {
     const anchorElement = $(element).find('a');
     let tmpLink = anchorElement.attr('href');
-    if (tmpLink[0] === '?' || tmpLink[0] === '/') tmpLink = link + tmpLink;
+    if (tmpLink[0] === '?') tmpLink = link + tmpLink;
+    else if (tmpLink[0] === '/') tmpLink = hostLink + tmpLink;
     contentLink.push(tmpLink);
   });
 


### PR DESCRIPTION
## 🤠 개요
- Closes: #23 
- 공지사항 크롤링을 구현했는데 3가지 절차가 필요해요
- 1. 학과 홈페이지에서 '공지사항'에 해당하는 링크 찾기
- 2. 어떤 공지사항들이 있는지 공지사항 리스트의 링크찾기
- 3. 해당 공지사항의 제목, 날짜, 본문내용, 링크 크롤링
- 자세한 내용은 아래에서 추가로 설명할게요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
학과별로 홈페이지의 개성이 워낙 강해서 크롤링을 하기 힘들었어요,,, 그래서 코드도 상당히 복잡해서 이해하기 힘들수 있어요,,,

## 1. 학과 홈페이지에서 '공지사항'에 해당하는 링크 찾기 
#### 크롤링된 단과대를 입력하면 해당 학과의 공지사항 링크가 반환돼요
``` ts
const findNoticeLink = (
  targetName: string,
  college: College,
  $: cheerio.CheerioAPI,
): string => {
  const selector = `:contains("${targetName}")`;
  const targetElements = $(selector);
  let noticeLink = '';
  let flag = true;

  targetElements.each((index, element) => {
    const link = $(element).attr('href');
    if (college.departmentName === '유아교육과' && flag) {
      noticeLink = '/education/1553';
      flag = false;
    } else if (link !== undefined && link !== '#none' && flag) {
      noticeLink = link;
      flag = false;
    }
  });

  return noticeLink;
};

export const noticeCrawling = async (college: College): Promise<string> => {
  let protocol = 'https://';
  if (college.departmentSubName === '의공학전공') {
    protocol = 'http://';
  } else if (college.departmentSubName === '공간정보시스템공학전공')
    return 'http://geoinfo.pknu.ac.kr/05piazza/08.php';
  const response = await axios.get(college.departmentLink);
  const hostLink = protocol + response.request._redirectable._options.hostname;
  const $ = cheerio.load(response.data);
  const noticeLink = hostLink + findNoticeLink('공지사항', college, $);

  if (noticeLink !== '') return noticeLink;

  return hostLink + findNoticeLink('공지사항(학부)', college, $);
};
```
- 부경대 학과소개 페이지에 있는 학과 URL이랑 실제 서비스중인 학과 홈페이지 URL 이 달라요. 국어국문학과로 예를들면 "http://kukmun.pknu.ac.kr" 주소인데 막상 접속해보면 redirection 이 돼서 "https://cms.pknu.ac.kr/korean/main.do" 로 주소가 리다이렉션돼요
- 그래서 axios로 "http://kukmun.pknu.ac.kr" 주소로 요청해서 hostname 을 찾아왔어요
- 그 다음 공지사항이라는 글자를 찾아 해당 링크를 반환하도록 했어요
- 공지사항이라는 글자는 상당히 많고 학부 공지사항, 대학원 공지사항 등 수많은 링크들이 있는데 대부분은 첫번째에 나온 링크가 학부 공지사항이었어요
- 그게 아닌경우는 수동으로 처리해줬어요

## 2. 어떤 공지사항들이 있는지 공지사항 리스트의 링크찾기
#### 공지사항 링크를 입력받으면 해당 페이지에 있는 공지사항들의 링크들을 배열로 반환해요
``` ts
export const noticeListCrawling = async (link: string): Promise<string[]> => {
  const response = await axios.get(link);
  const hostLink =
    'https://' + response.request._redirectable._options.hostname;
  const $ = cheerio.load(response.data);
  let tableData = $('table').find('tbody').find('tr');
  tableData = tableData.length > 0 ? tableData : $('ul#board_list').find('li');

  if (tableData.length < 1) console.error('테이블이 없음..');
  const contentLink: string[] = [];

  tableData.each((index, element) => {
    const anchorElement = $(element).find('a');
    let tmpLink = anchorElement.attr('href');
    if (tmpLink[0] === '?') tmpLink = link + tmpLink;
    else if (tmpLink[0] === '/') tmpLink = hostLink + tmpLink;
    contentLink.push(tmpLink);
  });

  return contentLink;
};
``` 
- 공지사항 리스트가 table로 되어있는경우, ul>li 로 되어있는 경우 2가지가 있었어요 그래서 이 두 방법을 이용해 공지사항 리스트를 크롤링 해왔어요

## 3. 해당 공지사항의 제목, 날짜, 본문내용, 링크 크롤링
#### 공지 상세페이지 링크를 입력받으면 공지사항의 제목, 날짜, 본문내용, 링크 데이터를 반환해요
``` ts
export const noticeContentCrawling = async (link: string) => {
  const response = await axios.get(link);
  const $ = cheerio.load(response.data);

  const contentData = $('div#board_view');
  if (contentData.length > 0) {
    const title = contentData.find('h3').text().trim();
    const date = contentData.find('p.writer strong').text().trim();
    const description = contentData
      .find('div.board_stance')
      .text()
      .trim()
      .replace(/\t|\n/g, '');
    const notice: Notice = { title, path: link, date, description };
    return notice;
  }

  const contentData2 = $('article#bo_v');
  if (contentData2.length > 0) {
    const title = contentData2.find('h2#bo_v_title').text().trim();
    const text = contentData2.find('strong.if_date').text().trim();
    const dateMatch = text.match(/(\d{2}-\d{2}-\d{2})/);
    const date = dateMatch ? dateMatch[1] : null;
    const description = contentData2
      .find('div#bo_v_con')
      .text()
      .trim()
      .replace(/\t|\n/g, '');
    const notice: Notice = { title, path: link, date, description };
    return notice;
  }

  const tables = $('table.a_brdList, table.c_brdView');
  if (tables.length > 0) {
    const title = tables.find('tr').eq(0).text().trim();
    const date = tables.find('tr').eq(1).find('td').first().text().trim();
    const description = tables
      .find('tr')
      .eq(3)
      .text()
      .trim()
      .replace(/\t|\n/g, '');
    const notice: Notice = { title, path: link, date, description };
    return notice;
  }

  const writeTable = $('table.write');
  if (writeTable.length > 0) {
    const title = writeTable.find('tr').first().find('td').text().trim();
    const date = writeTable
      .find('tr')
      .eq(2)
      .find('td')
      .text()
      .trim()
      .split(' ')[0];
    const description = writeTable
      .find('tr')
      .eq(4)
      .text()
      .trim()
      .replace(/\t|\n/g, '');
    const notice: Notice = { title, path: link, date, description };
    return notice;
  }

  const boardBoxTable = $('div#board_box table');
  if (boardBoxTable.length > 0) {
    const title = boardBoxTable.find('tr p').first().text().trim();
    const date = boardBoxTable.find('tr span').eq(1).text().trim();
    const description = boardBoxTable
      .find('tr')
      .eq(2)
      .text()
      .trim()
      .replace(/\t|\n/g, '');
    const notice: Notice = { title, path: link, date, description };
    return notice;
  }

  console.error('error!!!!');
};
```
- 공지사항 상세 페이지 역시 다양한 방법으로 구현되어 있었어요
- table, div, article 등 다양한 방법으로 되어 있어서 모든 경우를 다 추가하여 크롤링하도록 설정했어요

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
### 크롤링 되어 반환되는 데이터
<img width="1476" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/30ef4832-65dd-49d3-91cc-4d1a8c1ce5b9">

### 모든 학과의 첫번째 공지사항의 제목 출력 결과 
![image](https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/7a3ebe55-52a4-4e79-830b-e03e1af06fd0)
