### PR TITLE
Refactor/#28: 공지사항을 고정과 일반으로 분리하여 DB 에 저장

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   verbose: true,
   moduleNameMapper: {
     '@apis/(.*)': '<rootDir>/src/apis/$1',
-    '@config/(.*)': '<rootDir>/src/config/$1',
+    '@config': '<rootDir>/src/config',
     '@db/(.*)': '<rootDir>/src/db/$1',
     '@middlewares/(.*)': '<rootDir>/src/middleswares/$1',
     '@crawling/(.*)': '<rootDir>/src/crawling/$1',

--- a/src/apis/suggestion/service.ts
+++ b/src/apis/suggestion/service.ts
@@ -1,4 +1,4 @@
-import env from '@config/index';
+import env from '@config';
 import { Client } from '@notionhq/client';
 import { QueryDatabaseResponse } from '@notionhq/client/build/src/api-endpoints';
 

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -55,16 +55,24 @@ export const saveNoticeToDB = async () => {
           departmentSubName: row.departmentSubName,
           departmentLink: row.departmentLink,
         };
+        console.log(college.departmentName);
 
         const noticeLink = await noticeCrawling(college);
-        const noticeList = await noticeListCrawling(noticeLink);
-        for (const notice of noticeList) {
+        const noticeLists = await noticeListCrawling(noticeLink);
+        const major =
+          college.departmentSubName === '-'
+            ? college.departmentName
+            : college.departmentSubName;
+
+        if (noticeLists.pinnedNotice !== undefined) {
+          for (const notice of noticeLists.pinnedNotice) {
+            const result = await noticeContentCrawling(notice);
+            saveNotice(result, major + '고정');
+          }
+        }
+        for (const notice of noticeLists.normalNotice) {
           const result = await noticeContentCrawling(notice);
-          const major =
-            college.departmentSubName === '-'
-              ? college.departmentName
-              : college.departmentSubName;
-          saveNotice(result, major);
+          saveNotice(result, major + '일반');
         }
       }
     }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,4 +1,4 @@
-import env from '@config/index';
+import env from '@config';
 import mysql from 'mysql2';
 
 const db = mysql.createConnection({

--- a/src/db/table/createMajorTable.ts
+++ b/src/db/table/createMajorTable.ts
@@ -7,23 +7,25 @@ const createNoticeTable = (college: College[]) => {
       data.departmentSubName !== '-'
         ? data.departmentSubName
         : data.departmentName;
-    const createTableQuery = `CREATE TABLE ${major} (
-              id INT PRIMARY KEY AUTO_INCREMENT,
-              major VARCHAR(255) NOT NULL,
-              title VARCHAR(255) NOT NULL,
-              link VARCHAR(255) NOT NULL,
-              content TEXT NOT NULL,
-              uploadDate VARCHAR(255) NOT NULL,
-              graduate VARCHAR(255)
-          );`;
+    for (const tableName of [`${major}PinnedNoti`, `${major}Noti`]) {
+      const createTableQuery = `CREATE TABLE ${tableName} (
+                id INT PRIMARY KEY AUTO_INCREMENT,
+                major VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                link VARCHAR(255) NOT NULL,
+                content TEXT NOT NULL,
+                uploadDate VARCHAR(255) NOT NULL,
+                graduate VARCHAR(255)
+            );`;
 
-    db.query(createTableQuery, (error) => {
-      if (error) {
-        console.log('테이블 생성 실패', error);
-      } else {
-        console.log('테이블 생성 성공!');
-      }
-    });
+      db.query(createTableQuery, (error) => {
+        if (error) {
+          console.log('테이블 생성 실패', error);
+        } else {
+          console.log('테이블 생성 성공!');
+        }
+      });
+    }
   }
 };
 

--- a/src/db/table/createMajorTable.ts
+++ b/src/db/table/createMajorTable.ts
@@ -7,7 +7,7 @@ const createNoticeTable = (college: College[]) => {
       data.departmentSubName !== '-'
         ? data.departmentSubName
         : data.departmentName;
-    for (const tableName of [`${major}PinnedNoti`, `${major}Noti`]) {
+    for (const tableName of [`${major}고정`, `${major}일반`]) {
       const createTableQuery = `CREATE TABLE ${tableName} (
                 id INT PRIMARY KEY AUTO_INCREMENT,
                 major VARCHAR(255) NOT NULL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
-import { env } from 'process';
-
 import suggestionRouter from '@apis/suggestion/controller';
+import env from '@config';
 import { corsOptions } from '@middlewares/cors';
 import errorHandler from '@middlewares/error-handler';
 import cors from 'cors';
@@ -21,6 +20,6 @@ app.get('/test', (req: Request, res: Response) => {
   res.send('Hello');
 });
 
-app.listen(env.PORT, () => {
+app.listen(env.SERVER_PORT, () => {
   console.log('서버 실행중');
 });

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "@apis/*": ["src/apis/*"],
-      "@config/*": ["src/config/*"],
+      "@config": ["src/config"],
       "@db/*": ["src/db/*"],
       "@middlewares/*": ["src/middlewares/*"],
       "@crawling/*": ["src/crawling/*"]


### PR DESCRIPTION
## 🤠 개요

- closes: #28 
- 공지사항 리스트를 크롤링하면서 공지사항을 고정과 일반으로 분류하도록 크롤러를 설정했어요
- 고정과 일반을 분류하는 기준을 날짜 기준으로 해서 날짜가 더 커질때까지 고정 공지사항으로 저장하고 나머지는 일반 공지사항으로 저장했어요
- 근데 해당 분류가 되는 조건이 고정 공지사항이 날짜순으로 정렬되어있어야 한다는 전제가 있는데 모든 학과가 날짜순으로 정렬되어 있는건 아니에요 (일단 공간정보시스템공학과가 날짜순으로 정렬이 안되어 있더라고여..) 

<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 고려해야할점
- 공지사항을 크롤링하다가 에러가 한번씩 나는데 이건 크롤러에서 에러 발생하는 경우가 있고 홈페이지 접속 문제가 있는 경우 에러가 발생하는 경우 2가지가 있는거 같아요 
- 이후에 크롤러 만들때 DB 에 저장하는 방식 최적화가 필요하고, 크롤링 중 에러가 나는경우 다시 크롤링 요청하는 기능이 필요할거 같아요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
아래와 같이 테이블 이름을 모두 한글로 설정해뒀어요
<img width="351" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/6eb8bd01-c2b2-4bb4-bbe8-0c9ee9532b0a">
