### PR TITLE
Feat/#30: 단과대/학과, 학과에 해당하는 공지사항 반환하는 엔드포인트 제작

### DIFF
--- a/sqls/createTable.sql
+++ b/sqls/createTable.sql
@@ -7,3 +7,11 @@ CREATE TABLE departments (
     departmentSubName VARCHAR(255) NOT NULL,
     departmentLink VARCHAR(255) NOT NULL
 );
+
+CREATE TABLE schoolnotices {
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    link VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    uploadDate VARCHAR(255) NOT NULL,
+}

--- a/src/apis/majorDecision/controller.ts
+++ b/src/apis/majorDecision/controller.ts
@@ -1,0 +1,15 @@
+import { getColleges } from '@apis/majorDecision/service';
+import express, { Request, Response } from 'express';
+
+const router = express.Router();
+
+router.get('/', async (req: Request, res: Response) => {
+  try {
+    const colleges = await getColleges();
+    res.json(colleges);
+  } catch (err) {
+    console.log(err);
+  }
+});
+
+export default router;

--- a/src/apis/majorDecision/controller.ts
+++ b/src/apis/majorDecision/controller.ts
@@ -1,11 +1,11 @@
-import { getColleges } from '@apis/majorDecision/service';
+import { getCollegesName } from '@apis/majorDecision/service';
 import express, { Request, Response } from 'express';
 
 const router = express.Router();
 
 router.get('/', async (req: Request, res: Response) => {
   try {
-    const colleges = await getColleges();
+    const colleges = await getCollegesName();
     res.json(colleges);
   } catch (err) {
     console.log(err);

--- a/src/apis/majorDecision/controller.ts
+++ b/src/apis/majorDecision/controller.ts
@@ -1,4 +1,7 @@
-import { getCollegesName } from '@apis/majorDecision/service';
+import {
+  getCollegesName,
+  getDepartmentsName,
+} from '@apis/majorDecision/service';
 import express, { Request, Response } from 'express';
 
 const router = express.Router();
@@ -7,6 +10,15 @@ router.get('/', async (req: Request, res: Response) => {
   try {
     const colleges = await getCollegesName();
     res.json(colleges);
+  } catch (err) {
+    console.log(err);
+  }
+});
+
+router.get('/:college', async (req: Request, res: Response) => {
+  try {
+    const departments = await getDepartmentsName(req.params.college);
+    res.json(departments);
   } catch (err) {
     console.log(err);
   }

--- a/src/apis/majorDecision/service.ts
+++ b/src/apis/majorDecision/service.ts
@@ -4,7 +4,7 @@ interface CollegesName {
   collegeName: string;
 }
 
-export const getColleges = async () => {
+export const getCollegesName = async (): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const getCollegesQuery = `SELECT DISTINCT collegeName from departments ORDER BY collegeName;`;
     db.query(getCollegesQuery, (err: Error, res: CollegesName[]) => {

--- a/src/apis/majorDecision/service.ts
+++ b/src/apis/majorDecision/service.ts
@@ -4,6 +4,11 @@ interface CollegesName {
   collegeName: string;
 }
 
+interface DepartmentsName {
+  departmentName: string;
+  departmentSubName: string;
+}
+
 export const getCollegesName = async (): Promise<string[]> => {
   return new Promise((resolve, reject) => {
     const getCollegesQuery = `SELECT DISTINCT collegeName from departments ORDER BY collegeName;`;
@@ -14,6 +19,26 @@ export const getCollegesName = async (): Promise<string[]> => {
         colleges.push(college.collegeName);
       }
       resolve(colleges);
+    });
+  });
+};
+
+export const getDepartmentsName = async (
+  collegeName: string,
+): Promise<string[]> => {
+  return new Promise((resolve, reject) => {
+    const getDepartmentsQuery = `SELECT departmentName, departmentSubName FROM departments WHERE collegeName = '${collegeName}' ORDER BY departmentName;`;
+    db.query(getDepartmentsQuery, (err: Error, res: DepartmentsName[]) => {
+      if (err) reject(err);
+      const departments: string[] = [];
+      for (const department of res) {
+        const major =
+          department.departmentSubName === '-'
+            ? department.departmentName
+            : department.departmentName + ' ' + department.departmentSubName;
+        departments.push(major);
+      }
+      resolve(departments);
     });
   });
 };

--- a/src/apis/majorDecision/service.ts
+++ b/src/apis/majorDecision/service.ts
@@ -1,0 +1,19 @@
+import db from '@db/index';
+
+interface CollegesName {
+  collegeName: string;
+}
+
+export const getColleges = async () => {
+  return new Promise((resolve, reject) => {
+    const getCollegesQuery = `SELECT DISTINCT collegeName from departments ORDER BY collegeName;`;
+    db.query(getCollegesQuery, (err: Error, res: CollegesName[]) => {
+      if (err) reject(err);
+      const colleges: string[] = [];
+      for (const college of res) {
+        colleges.push(college.collegeName);
+      }
+      resolve(colleges);
+    });
+  });
+};

--- a/src/apis/notice/controller.ts
+++ b/src/apis/notice/controller.ts
@@ -1,0 +1,14 @@
+import { getNotices } from '@apis/notice/service';
+import express, { Request, Response } from 'express';
+
+const router = express.Router();
+router.get('/:major', async (req: Request, res: Response) => {
+  try {
+    const notices = await getNotices(req.params.major);
+    res.json(notices);
+  } catch (err) {
+    console.log(err);
+  }
+});
+
+export default router;

--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -1,0 +1,23 @@
+import db from '@db/index';
+import { Notice } from 'src/@types/college';
+
+export const getNotices = async (department: string): Promise<Notice[]> => {
+  const notices: Notice[] = [];
+
+  const getNoticesFromTable = (tableName: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const getNoticesQuery = `SELECT * FROM ${tableName}`;
+      db.query(getNoticesQuery, (err: Error, res: Notice[]) => {
+        if (err) reject(err);
+        notices.push(...res);
+        resolve();
+      });
+    });
+  };
+
+  await Promise.all([
+    getNoticesFromTable(`${department}고정`),
+    getNoticesFromTable(`${department}일반`),
+  ]);
+  return notices;
+};

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -145,5 +145,28 @@ export const noticeContentCrawling = async (link: string) => {
     return notice;
   }
 
+  const bdContTable = $('div.bdCont');
+  if (bdContTable.length > 0) {
+    const title = bdContTable
+      .find('tbody')
+      .first()
+      .find('tr')
+      .first()
+      .text()
+      .trim();
+    const date = bdContTable
+      .find('tbody')
+      .first()
+      .find('tr')
+      .eq(1)
+      .find('td')
+      .eq(3)
+      .text()
+      .trim();
+    const description = bdContTable.find('div.bdvTxt_wrap').text().trim();
+    const notice: Notice = { title, path: link, date, description };
+    return notice;
+  }
+
   console.error('error!!!!');
 };

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -70,3 +70,21 @@ export const saveNoticeToDB = async () => {
     }
   });
 };
+
+export const saveSchoolNoticeToDB = async () => {
+  const pknuNoticeLink = 'https://www.pknu.ac.kr/main/163';
+  const noticeLists = await noticeListCrawling(pknuNoticeLink);
+  for (const list of noticeLists) {
+    const notice = await noticeContentCrawling(list);
+    const saveNoticeQuery =
+      'INSERT INTO schoolnotices (title, link, content, uploadDate) VALUES (?, ?, ?, ?)';
+    const values = [notice.title, notice.path, notice.description, notice.date];
+    db.query(saveNoticeQuery, values, (error) => {
+      if (error) {
+        console.error('데이터 입력 실패', error);
+      } else {
+        console.log('공지사항 입력 성공!');
+      }
+    });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import majorRouter from '@apis/majorDecision/controller';
+import noticeRouter from '@apis/notice/controller';
 import suggestionRouter from '@apis/suggestion/controller';
 import env from '@config/index';
 import { corsOptions } from '@middlewares/cors';
@@ -16,6 +17,7 @@ app.use(errorHandler);
 
 app.use('/api/suggestion', suggestionRouter);
 app.use('/api/majorDecision', majorRouter);
+app.use('/api/announcement', noticeRouter);
 
 app.get('/test', (req: Request, res: Response) => {
   console.log('test');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { env } from 'process';
-
+import majorRouter from '@apis/majorDecision/controller';
 import suggestionRouter from '@apis/suggestion/controller';
+import env from '@config/index';
 import { corsOptions } from '@middlewares/cors';
 import errorHandler from '@middlewares/error-handler';
 import cors from 'cors';
@@ -15,12 +15,13 @@ app.use(express.json());
 app.use(errorHandler);
 
 app.use('/api/suggestion', suggestionRouter);
+app.use('/api/majorDecision', majorRouter);
 
 app.get('/test', (req: Request, res: Response) => {
   console.log('test');
   res.send('Hello');
 });
 
-app.listen(env.PORT, () => {
+app.listen(env.SERVER_PORT, () => {
   console.log('서버 실행중');
 });

--- a/src/tests/majorDecision.test.ts
+++ b/src/tests/majorDecision.test.ts
@@ -1,0 +1,58 @@
+const mockDbQuery = jest.fn(
+  (query: string, callback: (err: Error | null, res: College[]) => void) => {
+    const mockResponse = [
+      {
+        id: 5,
+        collegeName: '인문사회과학대학',
+        departmentName: '경제학과',
+        departmentSubName: '-',
+        departmentLink: 'https://econ.pknu.ac.kr',
+      },
+      {
+        id: 17,
+        collegeName: '자연과학대학',
+        departmentName: '간호학과',
+        departmentSubName: '-',
+        departmentLink: 'http://nursing.pknu.ac.kr',
+      },
+      {
+        id: 20,
+        collegeName: '경영대학',
+        departmentName: '국제통상학부',
+        departmentSubName: '-',
+        departmentLink: 'http://pknudic.pknu.ac.kr',
+      },
+      {
+        id: 21,
+        collegeName: '공과대학',
+        departmentName: '전기공학부',
+        departmentSubName: '전기공학전공',
+        departmentLink: 'http://electric-eng.pknu.ac.kr',
+      },
+    ];
+    callback(null, mockResponse);
+  },
+);
+
+import { getCollegesName } from '@apis/majorDecision/service';
+
+import { College } from './../@types/college';
+
+jest.mock('@db/index', () => ({
+  __esModule: true,
+  default: {
+    query: mockDbQuery,
+  },
+}));
+
+describe('단과대/학과 선택 테스트', () => {
+  it('단과대 선택 로직 테스트', async () => {
+    const result = await getCollegesName();
+    expect(result).toEqual([
+      '인문사회과학대학',
+      '자연과학대학',
+      '경영대학',
+      '공과대학',
+    ]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.path.json",
   "compilerOptions": {
-    "types": ["@types/jest"],
     "target": "ESNext",
     "module": "CommonJS",
     "esModuleInterop": true,
@@ -9,7 +8,7 @@
     "noImplicitAny": true,
     "skipLibCheck": true,
     "outDir": "./dist",
-    "typeRoots": ["../node_modules/@types", "./@types"],
+    "typeRoots": ["./node_modules/@types", "./@types"],
     "isolatedModules": true,
     "disableSourceOfProjectReferenceRedirect": true
   }


### PR DESCRIPTION
## 🤠 개요

- closes: #30 
- closes: #32
- 단과대/학과, 학과에 해당하는 공지사항 반환하는 엔드포인트 제작했어요! 값은 모두 DB 에서 쿼리문을 이용해 가져와서 반환하게 돼요
- 테스트코드를 작성해봤는데 현재 db query 문을 이용해 가져온 데이터를 반환하는데 db.query 의 반환값을 모킹하다보니 테스트코드의 의미가 없는거 같아서 추가적인 작성은 하지 않았어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 고민사항
- 현재 학과에 대한 변수를 major, department 를 바꿔가면서 사용하고 있는데 나중에 모두 통일하여 사용하도록 수정해야할 거 같아요

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
아래 테스트는 도커 환경에서 모든 데이터를 크롤링하여 테스트를 진행했어요!
<img width="414" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/4a5a265b-cccd-4a68-85ec-0a987f4cdfdc">
<img width="442" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/0d8cbda2-a028-4115-a033-68ac057e47b1">
<img width="731" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/0c7a362b-45cf-47f3-bba5-73f5e7305230">

