### PR TITLE
Feat/#33: 일부 오류 해결 및 서버 최초 실행 시 데이터추가하는 로직 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   database:
     image: mysql:8.0
     container_name: burimi-db
-    restart: unless-stopped
+    restart: always
     environment:
       - LANG=ko_KR.utf8
       - MYSQL_ROOT_PASSWORD=${DATABASE_ROOT_PASSWORD}

--- a/sqls/createTable.sql
+++ b/sqls/createTable.sql
@@ -8,7 +8,15 @@ CREATE TABLE departments (
     departmentLink VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE schoolnotices (
+CREATE TABLE 학교고정 (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    link VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    uploadDate VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE 학교일반 (
     id INT PRIMARY KEY AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     link VARCHAR(255) NOT NULL,

--- a/sqls/createTable.sql
+++ b/sqls/createTable.sql
@@ -8,10 +8,10 @@ CREATE TABLE departments (
     departmentLink VARCHAR(255) NOT NULL
 );
 
-CREATE TABLE schoolnotices {
+CREATE TABLE schoolnotices (
     id INT PRIMARY KEY AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     link VARCHAR(255) NOT NULL,
     content TEXT NOT NULL,
-    uploadDate VARCHAR(255) NOT NULL,
-}
+    uploadDate VARCHAR(255) NOT NULL
+);

--- a/src/apis/notice/controller.ts
+++ b/src/apis/notice/controller.ts
@@ -2,9 +2,10 @@ import { getNotices } from '@apis/notice/service';
 import express, { Request, Response } from 'express';
 
 const router = express.Router();
-router.get('/:major', async (req: Request, res: Response) => {
+router.get('/', async (req: Request, res: Response) => {
   try {
-    const notices = await getNotices(req.params.major);
+    const major = req.query.major as string;
+    const notices = await getNotices(major);
     res.json(notices);
   } catch (err) {
     console.log(err);

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -9,7 +9,6 @@ import db from 'src/db';
 export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
   const saveCollegePromises = college.map((data) => {
     const saveCollegeQuery = `INSERT INTO departments (collegeName, departmentName, departmentSubName, departmentLink) VALUES ('${data.collegeName}', '${data.departmentName}', '${data.departmentSubName}', '${data.departmentLink}');`;
-
     return new Promise<void>((resolve, reject) => {
       db.query(saveCollegeQuery, (error) => {
         if (error) {
@@ -30,7 +29,7 @@ export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
   }
 };
 
-const saveNotice = (notice: Notice, major: string) => {
+const saveNotice = (notice: Notice, major: string): Promise<void> => {
   const saveNoticeQuery =
     'INSERT INTO ' +
     major +
@@ -43,50 +42,68 @@ const saveNotice = (notice: Notice, major: string) => {
     notice.date,
   ];
 
-  db.query(saveNoticeQuery, values, (error) => {
-    if (error) {
-      console.error('데이터 입력 실패', error);
-    } else {
-      console.log('공지사항 입력 성공!');
-    }
+  return new Promise((resolve, reject) => {
+    db.query(saveNoticeQuery, values, (error) => {
+      if (error) {
+        console.error('데이터 입력 실패', error);
+        reject(error);
+      } else {
+        console.log('공지사항 입력 성공!');
+        resolve();
+      }
+    });
   });
 };
 
-export const saveNoticeToDB = async () => {
-  const selectQuery = 'SELECT * FROM departments';
-  db.query(selectQuery, async (error, results) => {
-    if (error) {
-      console.error('SELECT 오류:', error);
-    } else {
-      for (const row of results as College[]) {
-        const college: College = {
-          collegeName: row.collegeName,
-          departmentName: row.departmentName,
-          departmentSubName: row.departmentSubName,
-          departmentLink: row.departmentLink,
-        };
-        console.log(college.departmentName);
-
-        const noticeLink = await noticeCrawling(college);
-        const noticeLists = await noticeListCrawling(noticeLink);
-        const major =
-          college.departmentSubName === '-'
-            ? college.departmentName
-            : college.departmentSubName;
-
-        if (noticeLists.pinnedNotice !== undefined) {
-          for (const notice of noticeLists.pinnedNotice) {
-            const result = await noticeContentCrawling(notice);
-            saveNotice(result, major + '고정');
-          }
+export const saveNoticeToDB = async (): Promise<void> => {
+  const selectQuery = 'SELECT * FROM departments;';
+  try {
+    const results = (await new Promise((resolve, reject) => {
+      db.query(selectQuery, (error, results) => {
+        if (error) {
+          console.error('SELECT 오류:', error);
+          reject(error);
+        } else {
+          if (typeof results === 'string') resolve(results);
+          reject('타입 에러');
         }
-        for (const notice of noticeLists.normalNotice) {
+      });
+    })) as College[];
+
+    const savePromises: Promise<void>[] = [];
+
+    for (const row of results) {
+      const college: College = {
+        collegeName: row.collegeName,
+        departmentName: row.departmentName,
+        departmentSubName: row.departmentSubName,
+        departmentLink: row.departmentLink,
+      };
+
+      const noticeLink = await noticeCrawling(college);
+      const noticeLists = await noticeListCrawling(noticeLink);
+      const major =
+        college.departmentSubName === '-'
+          ? college.departmentName
+          : college.departmentSubName;
+
+      if (noticeLists.pinnedNotice !== undefined) {
+        for (const notice of noticeLists.pinnedNotice) {
           const result = await noticeContentCrawling(notice);
-          saveNotice(result, major + '일반');
+          savePromises.push(saveNotice(result, major + '고정'));
         }
       }
+
+      for (const notice of noticeLists.normalNotice) {
+        const result = await noticeContentCrawling(notice);
+        savePromises.push(saveNotice(result, major + '일반'));
+      }
     }
-  });
+
+    await Promise.all(savePromises);
+  } catch (error) {
+    console.error('에러 발생:', error);
+  }
 };
 
 const saveSchoolNotice = async (notices: string[], mode: string) => {

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -89,14 +89,41 @@ export const saveNoticeToDB = async (): Promise<void> => {
           : college.departmentSubName;
 
       if (noticeLists.pinnedNotice !== undefined) {
+        const pinnedNotiQuery = `SELECT link FROM ${major}고정 ORDER BY uploadDate DESC LIMIT 1;`;
+        let pinnedNotiLink = '';
+        db.query(pinnedNotiQuery, (err, res) => {
+          if (err) {
+            console.log(err);
+          } else {
+            const rows = res as RowDataPacket[];
+            if (Array.isArray(rows) && rows.length > 0) {
+              pinnedNotiLink = rows[0].link;
+            }
+          }
+        });
+
         for (const notice of noticeLists.pinnedNotice) {
           const result = await noticeContentCrawling(notice);
+          if (result.path === pinnedNotiLink) break;
           savePromises.push(saveNotice(result, major + '고정'));
         }
       }
 
+      const normalNotiQuery = `SELECT link FROM ${major}고정 ORDER BY uploadDate DESC LIMIT 1;`;
+      let normalNotiLink = '';
+      db.query(normalNotiQuery, (err, res) => {
+        if (err) {
+          console.log(err);
+        } else {
+          const rows = res as RowDataPacket[];
+          if (Array.isArray(rows) && rows.length > 0) {
+            normalNotiLink = rows[0].link;
+          }
+        }
+      });
       for (const notice of noticeLists.normalNotice) {
         const result = await noticeContentCrawling(notice);
+        if (result.path === normalNotiLink) break;
         savePromises.push(saveNotice(result, major + '일반'));
       }
     }

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -6,17 +6,27 @@ import {
 import { College, Notice } from 'src/@types/college';
 import db from 'src/db';
 
-export const saveDepartmentToDB = async (college: College[]) => {
-  for (const data of college) {
+export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
+  const saveCollegePromises = college.map((data) => {
     const saveCollegeQuery = `INSERT INTO departments (collegeName, departmentName, departmentSubName, departmentLink) VALUES ('${data.collegeName}', '${data.departmentName}', '${data.departmentSubName}', '${data.departmentLink}');`;
 
-    db.query(saveCollegeQuery, (error) => {
-      if (error) {
-        console.error('데이터 입력 실패', error);
-      } else {
-        console.log('단과대 입력 성공!');
-      }
+    return new Promise<void>((resolve, reject) => {
+      db.query(saveCollegeQuery, (error) => {
+        if (error) {
+          console.error('데이터 입력 실패', error);
+          reject(error);
+        } else {
+          console.log('단과대 입력 성공!');
+          resolve();
+        }
+      });
     });
+  });
+
+  try {
+    await Promise.all(saveCollegePromises);
+  } catch (err) {
+    console.log(err);
   }
 };
 

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -148,7 +148,6 @@ const saveSchoolNotice = async (
           const rows = res as RowDataPacket[];
           if (Array.isArray(rows) && rows.length > 0) {
             const link = rows[0].link;
-            console.log(link);
             resolve(link);
           } else {
             resolve('');

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -59,17 +59,16 @@ const saveNotice = (notice: Notice, major: string): Promise<void> => {
 export const saveNoticeToDB = async (): Promise<void> => {
   const selectQuery = 'SELECT * FROM departments;';
   try {
-    const results = (await new Promise((resolve, reject) => {
+    const results = await new Promise<College[]>((resolve, reject) => {
       db.query(selectQuery, (error, results) => {
         if (error) {
           console.error('SELECT 오류:', error);
           reject(error);
         } else {
-          if (typeof results === 'string') resolve(results);
-          reject('타입 에러');
+          resolve(results as College[]);
         }
       });
-    })) as College[];
+    });
 
     const savePromises: Promise<void>[] = [];
 

--- a/src/hooks/startCrawlingData.ts
+++ b/src/hooks/startCrawlingData.ts
@@ -1,0 +1,29 @@
+import { collegeCrawling } from '@crawling/collegeCrawling';
+import {
+  saveDepartmentToDB,
+  saveNoticeToDB,
+  saveSchoolNoticeToDB,
+} from '@db/data/handler';
+import db from '@db/index';
+import createNoticeTable from '@db/table/createMajorTable';
+import { RowDataPacket } from 'mysql2';
+
+export const initialCrawling = () => {
+  try {
+    const findrowsExistQuery = 'SELECT COUNT(*) FROM departments;';
+    db.query(findrowsExistQuery, async (err, res) => {
+      if (err) return;
+      const rows = res as RowDataPacket[];
+      if (rows[0]['COUNT(*)'] !== 0) return;
+      const collegeList = await collegeCrawling();
+      createNoticeTable(collegeList);
+      await saveDepartmentToDB(collegeList);
+      await saveSchoolNoticeToDB();
+      await saveNoticeToDB();
+    });
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+// const startNoticeCrawling = () => {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-import majorRouter from '@apis/majorDecision/controller';
-import noticeRouter from '@apis/notice/controller';
-import suggestionRouter from '@apis/suggestion/controller';
 import env from '@config';
 import { corsOptions } from '@middlewares/cors';
 import errorHandler from '@middlewares/error-handler';
@@ -15,9 +12,19 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 app.use(express.json());
 app.use(errorHandler);
 
-app.use('/api/suggestion', suggestionRouter);
-app.use('/api/majorDecision', majorRouter);
-app.use('/api/announcement', noticeRouter);
+setTimeout(() => {
+  import('@apis/majorDecision/controller').then((majorRouter) => {
+    app.use('/api/majorDecision', majorRouter.default);
+  });
+
+  import('@apis/notice/controller').then((suggestionRouter) => {
+    app.use('/api/suggestion', suggestionRouter.default);
+  });
+
+  import('@apis/suggestion/controller').then((noticeRouter) => {
+    app.use('/api/announcement', noticeRouter.default);
+  });
+}, 15000);
 
 app.get('/test', (req: Request, res: Response) => {
   console.log('test');

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,11 @@ setTimeout(() => {
     app.use('/api/majorDecision', majorRouter.default);
   });
 
-  import('@apis/notice/controller').then((suggestionRouter) => {
+  import('@apis/suggestion/controller').then((suggestionRouter) => {
     app.use('/api/suggestion', suggestionRouter.default);
   });
 
-  import('@apis/suggestion/controller').then((noticeRouter) => {
+  import('@apis/notice/controller').then((noticeRouter) => {
     app.use('/api/announcement', noticeRouter.default);
   });
 }, 15000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ app.use(express.json());
 app.use(errorHandler);
 
 setTimeout(() => {
+  import('src/hooks/startCrawlingData').then((crawling) => {
+    crawling.initialCrawling();
+  });
+
   import('@apis/majorDecision/controller').then((majorRouter) => {
     app.use('/api/majorDecision', majorRouter.default);
   });


### PR DESCRIPTION
## 🤠 개요

- closes: #33 
- 작업하다보니 작업량 분배 실패하고 한 번에 많이 올라갔어요.. 🥲
- 학교 공지사항도 고정/일반 2개의 테이블로 나눴어요
- 서버가 DB 와 연결할때까지 기다리기 위해 서버 실행 후 15초뒤 라우팅 및 일부 로직들이 적용되도록 수정했어요
- 크롤링하여 DB에 저장하는 함수를 Promise 를 반환하는 비동기함수로 변경했어요
- 공지사항 크롤링 시 가장 최신 공지사항의 URL 링크와 비교하여 같은 경우 크롤링을 멈추게 설정했어요
- 서버 최초 실행 시 DB에 테이블을 만들고 모든 데이터를 크롤링하는 모듈을 만들어 index.ts 에 추가해뒀어요
<!--

- 이슈번호
- 한줄 설명

-->
## 💫 설명
### _학교 공지사항도 고정/일반 2개의 테이블로 나눴어요._
- 이전 PR에서 학과 공지사항은 고정/일반으로 나눴지만 학교공지사항은 고정/일반으로 나누지 않아 코드 에러가 발생하고 있었어요. 
- 그리고 테이블을 생성하는 sql 코드도 잘못되어 있었어요
- 그렇기에 테이블을 고정, 일반 2개로 나누고 테이블 이름을 영어에서 한글로 변경해줬어요
---

### _서버가 DB 와 연결할때까지 기다리기 위해 서버 실행 후 15초뒤 라우팅 및 일부 로직들이 적용되도록 수정했어요_
- 현재 도커로 설정된 mysql 이 첫 실행 시 .env 파일을 못 읽어와 에러를 내며 종료가 되지만 다시 실행하면 정상적으로 .env 파일값을 읽어와 정상적으로 동작하는 중이에요
- 정확한 이유는 모르겠지만 해당 문제를 해결하기 위해 15초뒤에 로직이 실행되게 설정하여 데이터베이스와 연결이 된 후에 동작하도록 설정해뒀어요
- 하지만 임시방편으로 추후 더 좋은 방법을 찾아서 수정하는게 좋을거 같아요
---

### _크롤링하여 DB에 저장하는 함수를 Promise 를 반환하는 비동기함수로 변경했어요_
- 크롤링하여 DB에 넣는 함수를 Promise.all 을 이용해 Promise를 반환하는 함수로 바꿨어요
- 이유는 데이터베이스에 접근하는 2개의 함수가 한 번에 실행되면 에러가 발생하기에 하나의 함수가 종료되면 다음 함수를 실행하기 위해 반환값을 바꿔줬어요
- 나중에 로직을 개선해서 크롤링의 속도를 올려봐도 좋을거 같아요!
---

### _공지사항 크롤링 시 가장 최신 공지사항의 URL 링크와 비교하여 같은 경우 크롤링을 멈추게 설정했어요_
- 데이터베이스를 찾아보니 데이터를 순차적으로 넣어도 값을 순차적으로 저장하지 않는다고 해요. 그렇기에 크롤링한 데이터를 역순으로 저장한다고 의미가 있을거 같진 않아서 해당 방식을 이용했어요!
- 일단 `order by uploadDate desc limit 1` 을 이용해 가장 최근에 업로드된 공지사항의 URL 링크값을 가져와 현재 크롤링할 URL 링크를 비교하여 만약 같다면 크롤링을 멈추게 설정해뒀어요
- 하지만 공지사항이 같은날 여러개 올라오는 경우 예상치 못한 동작이 일어날 수 있어요
- 현재 고민사항인데 DB에 데이터를 저장하는 시간을 저장해서 가장 최근에 DB에 저장된 공지사항의 URL 주소를 이용하는게 더 좋을거 같다는 생각이 들어요
---

## _고민사항_
- 아직 완전 제대로 동작하는지 테스트는 못해봐서 중간에 에러가 날 수도 있어요,, 
- 코드에 리팩토링이 제대로 되지 않아 완전 레거시코드인데 나중에 날잡고 리팩토링 해야겠어요,,

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
