### PR TITLE
Fix/#38: 공지사항 요청 하는 함수 에러 핸들링 추가

### DIFF
--- a/src/apis/notice/controller.ts
+++ b/src/apis/notice/controller.ts
@@ -5,6 +5,9 @@ const router = express.Router();
 router.get('/', async (req: Request, res: Response) => {
   try {
     const major = req.query.major as string;
+    if (major === undefined) {
+      res.status(404).json('학과를 입력해주세요');
+    }
     const notices = await getNotices(major);
     res.json(notices);
   } catch (err) {

--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -9,7 +9,7 @@ export const getNotices = async (department: string): Promise<Notice[]> => {
       const getNoticesQuery = `SELECT * FROM ${tableName}`;
       db.query(getNoticesQuery, (err: Error, res: Notice[]) => {
         if (err) reject(err);
-        notices.push(...res);
+        if (res !== undefined && res.length > 0) notices.push(...res);
         resolve();
       });
     });
@@ -19,5 +19,6 @@ export const getNotices = async (department: string): Promise<Notice[]> => {
     getNoticesFromTable(`${department}고정`),
     getNoticesFromTable(`${department}일반`),
   ]);
+
   return notices;
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #38 
- 쿼리 파라미터가 없는 경우, DB에 저장된 데이터가 없는 경우 에러 핸들링을 추가하여 서버가 종료되지 않도록 수정했어요!
- 추후 response 의 status 값에 대해 추가하고 클라이언트측에도 에러 핸들링을 추가하는게 좋을거 같아요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
