### PR TITLE
Refactor: 공지사항을 고정, 일반 나눠서 반환하도록 변경

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -1,6 +1,11 @@
 import db from '@db/index';
 import { Notice } from 'src/@types/college';
 
+interface SeparateNoti {
+  고정: Notice[];
+  일반: Notice[];
+}
+
 const getNoticesFromTable = (tableName: string) => {
   return new Promise<Notice[]>((resolve, reject) => {
     const getNoticesQuery = `SELECT * FROM ${tableName}`;
@@ -12,26 +17,28 @@ const getNoticesFromTable = (tableName: string) => {
   });
 };
 
-export const getNotices = async (department: string): Promise<Notice[]> => {
-  const notices: Notice[] = [];
-
+export const getNotices = async (department: string): Promise<SeparateNoti> => {
   const [fixNotices, normalNotices] = await Promise.all([
     getNoticesFromTable(`${department}고정`),
     getNoticesFromTable(`${department}일반`),
   ]);
 
-  notices.push(...fixNotices, ...normalNotices);
+  const notices: SeparateNoti = {
+    고정: [...fixNotices],
+    일반: [...normalNotices],
+  };
   return notices;
 };
 
-export const getSchoolNotices = async (): Promise<Notice[]> => {
-  const notices: Notice[] = [];
-
+export const getSchoolNotices = async (): Promise<SeparateNoti> => {
   const [fixNotices, normalNotices] = await Promise.all([
     getNoticesFromTable('학교고정'),
     getNoticesFromTable('학교일반'),
   ]);
 
-  notices.push(...fixNotices, ...normalNotices);
+  const notices: SeparateNoti = {
+    고정: [...fixNotices],
+    일반: [...normalNotices],
+  };
   return notices;
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #57 
- 공지사항을 고정, 일반 나눠서 반환하도록 변경했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
<img width="702" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/f88705a5-a60b-462c-a29d-2b13f7e2d5f8">
<img width="532" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/c860617c-ddc2-4063-a4ae-6a0b8cda3c45">
