### PR TITLE
Fix/#68: 특정 공지사항 크롤링 시 제목에 내용도 같이 크롤링되는 문제 수정

### DIFF
--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -132,7 +132,7 @@ export const noticeContentCrawling = async (link: string) => {
 
   const contentData = $('div#board_view');
   if (contentData.length > 0) {
-    const title = contentData.find('h3').text().trim();
+    const title = contentData.find('h3').first().text().trim();
     const date = contentData.find('p.writer strong').text().trim();
     const description = contentData
       .find('div.board_stance')

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -111,11 +111,9 @@ export const saveNoticeToDB = async (): Promise<void> => {
           if (Array.isArray(rows) && rows.length > 0) {
             normalNotiLink = rows[0].link;
           }
-          console.log('일반', normalNotiLink);
           for (const notice of noticeLists.normalNotice) {
             const result = await noticeContentCrawling(notice);
             if (result.path === normalNotiLink) {
-              console.log(major, '일반 좀 되라');
               break;
             }
             savePromises.push(saveNotice(result, major + '일반'));


### PR DESCRIPTION
## 🤠 개요

- closes: #68 
- 특정 공지사항 크롤링 시 제목에 내용도 같이 크롤링되는 문제 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
- 사진과 같이 제목은 첫번째 h3 태그를 이용하는데, 본문 내용도 h3 태그를 사용하여 생기는 문제였어요
- 그래서 제목의 경우 h3의 첫번째 값만 가져오는걸로 수정했어요!
<img width="224" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/9aa5a5b8-3d17-44c6-8d2a-9db9aa9374c6">

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
