### PR TITLE
Refactor/#81: 중복된 공지사항이 DB에 저장 안되도록 수정

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -8,7 +8,7 @@ interface SeparateNoti {
 
 const getNoticesFromTable = (tableName: string) => {
   return new Promise<Notice[]>((resolve, reject) => {
-    const getNoticesQuery = `SELECT * FROM ${tableName}`;
+    const getNoticesQuery = `SELECT * FROM ${tableName} ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC;`;
     db.query(getNoticesQuery, (err: Error, res: Notice[]) => {
       if (err) reject(err);
       if (res !== undefined && res.length > 0) resolve(res);

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -23,11 +23,7 @@ export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
     });
   });
 
-  try {
-    await Promise.all(saveCollegePromises);
-  } catch (err) {
-    console.log(err);
-  }
+  await Promise.all(saveCollegePromises);
 };
 
 const saveNotice = (notice: Notice, major: string): Promise<void> => {
@@ -52,65 +48,65 @@ const saveNotice = (notice: Notice, major: string): Promise<void> => {
 
 export const saveNoticeToDB = async (): Promise<void> => {
   const selectQuery = 'SELECT * FROM departments;';
-  try {
-    const results = await new Promise<College[]>((resolve, reject) => {
-      db.query(selectQuery, (error, results) => {
-        if (error) {
-          console.error('SELECT 오류:', error);
-          reject(error);
-        } else {
-          resolve(results as College[]);
-        }
-      });
-    });
-
-    const savePromises: Promise<void>[] = [];
-
-    for (const row of results) {
-      const college: College = {
-        collegeName: row.collegeName,
-        departmentName: row.departmentName,
-        departmentSubName: row.departmentSubName,
-        departmentLink: row.departmentLink,
-      };
-
-      const noticeLink = await noticeCrawling(college);
-      const noticeLists = await noticeListCrawling(noticeLink);
-      const major =
-        college.departmentSubName === '-'
-          ? college.departmentName
-          : college.departmentSubName;
-
-      if (noticeLists.pinnedNotice !== undefined) {
-        const pinnedNotiQuery = `SELECT link FROM ${major}고정 ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
-        let pinnedNotiLink = '';
-        db.query(pinnedNotiQuery, async (err, res) => {
-          if (err) {
-            console.log(err);
-          } else {
-            const rows = res as RowDataPacket[];
-            if (Array.isArray(rows) && rows.length > 0) {
-              pinnedNotiLink = rows[0].link;
-            }
-            for (const notice of noticeLists.pinnedNotice) {
-              const result = await noticeContentCrawling(notice);
-              if (result.path === pinnedNotiLink) break;
-              savePromises.push(saveNotice(result, major + '고정'));
-            }
-          }
-        });
+  const results = await new Promise<College[]>((resolve, reject) => {
+    db.query(selectQuery, (error, results) => {
+      if (error) {
+        console.error('SELECT 오류:', error);
+        reject(error);
+      } else {
+        resolve(results as College[]);
       }
+    });
+  });
 
-      const normalNotiQuery = `SELECT link FROM ${major}일반 ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
-      let normalNotiLink = '';
-      db.query(normalNotiQuery, async (err, res) => {
+  const savePromises: Promise<void>[] = [];
+
+  for (const row of results) {
+    const college: College = {
+      collegeName: row.collegeName,
+      departmentName: row.departmentName,
+      departmentSubName: row.departmentSubName,
+      departmentLink: row.departmentLink,
+    };
+
+    const noticeLink = await noticeCrawling(college);
+    const noticeLists = await noticeListCrawling(noticeLink);
+    const major =
+      college.departmentSubName === '-'
+        ? college.departmentName
+        : college.departmentSubName;
+
+    if (noticeLists.pinnedNotice !== undefined) {
+      const pinnedNotiQuery = `SELECT link FROM ${major}고정 ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
+      let pinnedNotiLink = '';
+      db.query(pinnedNotiQuery, async (err, res) => {
         if (err) {
           console.log(err);
         } else {
           const rows = res as RowDataPacket[];
           if (Array.isArray(rows) && rows.length > 0) {
-            normalNotiLink = rows[0].link;
+            pinnedNotiLink = rows[0].link;
           }
+          for (const notice of noticeLists.pinnedNotice) {
+            const result = await noticeContentCrawling(notice);
+            if (result.path === pinnedNotiLink) break;
+            savePromises.push(saveNotice(result, major + '고정'));
+          }
+        }
+      });
+    }
+
+    const normalNotiQuery = `SELECT link FROM ${major}일반 ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
+    let normalNotiLink = '';
+    db.query(normalNotiQuery, async (err, res) => {
+      if (err) {
+        console.log(err);
+      } else {
+        try {
+          const rows = res as RowDataPacket[];
+          if (Array.isArray(rows) && rows.length > 0)
+            normalNotiLink = rows[0].link;
+
           for (const notice of noticeLists.normalNotice) {
             const result = await noticeContentCrawling(notice);
             if (result.path === normalNotiLink) {
@@ -118,14 +114,14 @@ export const saveNoticeToDB = async (): Promise<void> => {
             }
             savePromises.push(saveNotice(result, major + '일반'));
           }
+        } catch (error) {
+          console.log('cheerio 에러', error);
         }
-      });
-    }
-
-    await Promise.all(savePromises);
-  } catch (error) {
-    console.error('에러 발생:', error);
+      }
+    });
   }
+
+  await Promise.all(savePromises);
 };
 
 const saveSchoolNotice = async (
@@ -133,56 +129,51 @@ const saveSchoolNotice = async (
   mode: string,
 ): Promise<Promise<void>[]> => {
   const query = `SELECT link FROM 학교${mode} ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
-  try {
-    const res = await new Promise<string>((resolve, reject) => {
-      db.query(query, (err, res) => {
-        if (err) {
-          reject(err);
+  const res = await new Promise<string>((resolve, reject) => {
+    db.query(query, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        const rows = res as RowDataPacket[];
+        if (Array.isArray(rows) && rows.length > 0) {
+          const link = rows[0].link;
+          resolve(link);
         } else {
-          const rows = res as RowDataPacket[];
-          if (Array.isArray(rows) && rows.length > 0) {
-            const link = rows[0].link;
-            resolve(link);
-          } else {
-            resolve('');
-          }
+          resolve('');
         }
-      });
+      }
     });
+  });
 
-    const saveNoticeQuery = `INSERT INTO 학교${mode} (title, link, content, uploadDate) VALUES (?, ?, ?, ?);`;
-    const savePromises: Promise<void>[] = [];
+  const saveNoticeQuery = `INSERT INTO 학교${mode} (title, link, content, uploadDate) VALUES (?, ?, ?, ?);`;
+  const savePromises: Promise<void>[] = [];
 
-    for (const list of notices) {
-      const notice = await noticeContentCrawling(list);
-      if (res === notice.path) break;
+  for (const list of notices) {
+    const notice = await noticeContentCrawling(list);
+    if (res === notice.path) break;
 
-      savePromises.push(
-        new Promise<void>((resolve, reject) => {
-          const values = [
-            notice.title,
-            notice.path,
-            notice.description,
-            notice.date,
-          ];
-          db.query(saveNoticeQuery, values, (error) => {
-            if (error) {
-              console.error('데이터 입력 실패', error);
-              reject(error);
-            } else {
-              console.log('학교 공지사항 입력 성공!');
-              resolve();
-            }
-          });
-        }),
-      );
-    }
-
-    return savePromises;
-  } catch (error) {
-    console.error('에러 발생:', error);
-    return [];
+    savePromises.push(
+      new Promise<void>((resolve, reject) => {
+        const values = [
+          notice.title,
+          notice.path,
+          notice.description,
+          notice.date,
+        ];
+        db.query(saveNoticeQuery, values, (error) => {
+          if (error) {
+            console.error('데이터 입력 실패', error);
+            reject(error);
+          } else {
+            console.log('학교 공지사항 입력 성공!');
+            resolve();
+          }
+        });
+      }),
+    );
   }
+
+  return savePromises;
 };
 
 export const saveSchoolNoticeToDB = async (): Promise<void> => {

--- a/src/db/table/createTables.ts
+++ b/src/db/table/createTables.ts
@@ -45,7 +45,7 @@ const createNoticeTable = (college: College[]) => {
       const createTableQuery = `CREATE TABLE ${tableName} (
                 id INT PRIMARY KEY AUTO_INCREMENT,
                 title VARCHAR(255) NOT NULL,
-                link VARCHAR(255) NOT NULL,
+                link VARCHAR(255) NOT NULL UNIQUE,
                 content TEXT NOT NULL,
                 uploadDate VARCHAR(255) NOT NULL
             );`;
@@ -66,7 +66,7 @@ const createSchoolNoticeTable = () => {
     const createTableQuery = `CREATE TABLE ${tableName} (
       id INT PRIMARY KEY AUTO_INCREMENT,
       title VARCHAR(255) NOT NULL,
-      link VARCHAR(255) NOT NULL,
+      link VARCHAR(255) NOT NULL UNIQUE,
       content TEXT NOT NULL,
       uploadDate VARCHAR(255) NOT NULL
           );`;


### PR DESCRIPTION
## 🤠 개요

- closes: #81 
- 불필요한 try ~ catch문을 제거했어요
- 중복된 공지사항이 DB에 저장 안되도록 수정했어요
- 공지사항 불러올 때 날짜순으로 정렬되어 반환하도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 공지사항 클롤링 시 에러
- cheerio에서 문제가 있는지 크롤링하면서 한 번씩 에러가 발생할 때가 있어요
- 그래서 크롤링 실패하면 크롤링을 중지했었는데, 에러가 발생하면 해당 학과를 제외하고 나머지 학과들은 그대로 크롤링 진행하도록 설정했어요

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
