### PR TITLE
Feat/#83: slack 으로 알림을 받을 수 있는 훅 추가

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,4 +15,5 @@ export default {
   VAPID_PUBLIC_KEY: process.env.VAPID_PUBLIC_KEY,
   VAPID_PRIVATE_KEY: process.env.VAPID_PRIVATE_KEY,
   ROOT_EMAIL: process.env.ROOT_EMAIL,
+  SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL,
 };

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -62,8 +62,10 @@ export const noticeListCrawling = async (
       : $('ul#board_list, ul.c_glyList').find('li');
 
   if (tableData.length < 1) {
-    console.error('테이블이 없음..');
-    return Promise.reject('테이블이 없음..');
+    const tmp: NoticeLists = {
+      normalNotice: [],
+    };
+    return Promise.reject(tmp);
   }
 
   let beforeDate: string;

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -130,7 +130,7 @@ export const noticeListCrawling = async (
   }
 };
 
-export const noticeContentCrawling = async (link: string) => {
+export const noticeContentCrawling = async (link: string): Promise<Notice> => {
   const response = await axios.get(link);
   const $ = cheerio.load(response.data);
 
@@ -233,5 +233,5 @@ export const noticeContentCrawling = async (link: string) => {
     return notice;
   }
 
-  console.error('error!!!!');
+  return { title: '', path: '', date: '', description: '' };
 };

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -95,6 +95,10 @@ export const saveNoticeToDB = async (): Promise<void> => {
           }
           for (const notice of noticeLists.pinnedNotice) {
             const result = await noticeContentCrawling(notice);
+            if (result.path === '') {
+              notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+              continue;
+            }
             if (result.path === pinnedNotiLink) break;
             savePromises.push(saveNotice(result, major + '고정'));
           }
@@ -115,6 +119,10 @@ export const saveNoticeToDB = async (): Promise<void> => {
 
           for (const notice of noticeLists.normalNotice) {
             const result = await noticeContentCrawling(notice);
+            if (result.path === '') {
+              notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+              continue;
+            }
             if (result.path === normalNotiLink) {
               break;
             }
@@ -156,6 +164,10 @@ const saveSchoolNotice = async (
 
   for (const list of notices) {
     const notice = await noticeContentCrawling(list);
+    if (notice.path === '') {
+      notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+      continue;
+    }
     if (res === notice.path) break;
 
     savePromises.push(

--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -6,6 +6,7 @@ import {
 import { RowDataPacket } from 'mysql2';
 import { College, Notice } from 'src/@types/college';
 import db from 'src/db';
+import notificationToSlack from 'src/hooks/notificateToSlack';
 
 export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
   const saveCollegePromises = college.map((data) => {
@@ -71,6 +72,11 @@ export const saveNoticeToDB = async (): Promise<void> => {
 
     const noticeLink = await noticeCrawling(college);
     const noticeLists = await noticeListCrawling(noticeLink);
+    if (noticeLists.normalNotice.length === 0) {
+      notificationToSlack(`${noticeLink} 크롤링 실패`);
+      continue;
+    }
+
     const major =
       college.departmentSubName === '-'
         ? college.departmentName

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -1,6 +1,12 @@
 import { saveNoticeToDB } from '@db/data/handler';
 import cron from 'node-cron';
+import notificationToSlack from 'src/hooks/notificateToSlack';
 
-cron.schedule('0 2 * * *', () => {
-  saveNoticeToDB();
+cron.schedule('0 2 * * *', async () => {
+  await saveNoticeToDB();
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1; // 월은 0부터 시작하므로 1을 더해줍니다.
+  const day = today.getDate();
+  notificationToSlack(`${year}-${month}-${day} 크롤링 완료`);
 });

--- a/src/hooks/notificateToSlack.ts
+++ b/src/hooks/notificateToSlack.ts
@@ -1,0 +1,13 @@
+import env from '@config';
+import axios from 'axios';
+
+const notificationToSlack = (text: string) => {
+  axios.post(env.SLACK_WEBHOOK_URL, {
+    Headers: {
+      'Content-type': 'application/json',
+    },
+    text,
+  });
+};
+
+export default notificationToSlack;

--- a/src/hooks/notificateToSlack.ts
+++ b/src/hooks/notificateToSlack.ts
@@ -1,13 +1,18 @@
 import env from '@config';
 import axios from 'axios';
 
-const notificationToSlack = (text: string) => {
-  axios.post(env.SLACK_WEBHOOK_URL, {
+const notificationToSlack = async (text: string): Promise<void> => {
+  if (process.env.NODE_ENV === 'development') {
+    console.error(text);
+    return;
+  }
+  await axios.post(env.SLACK_WEBHOOK_URL, {
     Headers: {
       'Content-type': 'application/json',
     },
     text,
   });
+  return;
 };
 
 export default notificationToSlack;


### PR DESCRIPTION
## 🤠 개요

- closes: #83 
- slack 의 웹훅으로 알림을 받을 수 있도록 추가했어요
- 만약 크롤링의 문제가 있다면 알림을 받을 수 있도록 추가했어요
- 졸업요건 크롤링 코드는 건들지 않았어요,,

<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 알림이 울리는 경우
### 매일 02시에 크롤링 후 알림 오도록 설정
- 매일 크롤링 했는지, 서버가 잘 살아있는지 간단하게 확인할 수 있게 하기위해 매일 알림이 오도록 설정했어요
- slack 알림이 새벽에는 울리지 않아서 수면 방해는 없을거에요!

### noticeList, noticeContent 크롤링 실패 시
- 크롤링 실패 시 실패한 URL을 함께 slack에 알림을 주도록 설정했어요

### DB 쿼리문 실패 시
- select 및 insert 문이 실패하는 경우에도 알림을 받을 수 있도록 했어요.
- 하지만 실패하는 경우가 거의 없을거라 생각하고 있어요

### 공지사항을 DB 저장 실패 시 (해당 경우는 알림 안옴)
- 중복된 공지사항을 저장하려고 하면 에러가 발생하기 때문에 만약 알림을 켜두면 상당히 많은 알림을 받을거에요
- 해당 경우는 알림설정을 하지 않았어요

## dotenv-vault
- 현재 dotenv-vault 가 정상적으로 동작하지 않는거 같아요
- 해당 문제는 대면 회의를 통해서 얘기해봐요!

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
