### PR TITLE
Fix/#86: 배포 서버의 불필요한 로그 제거

### DIFF
--- a/src/db/data/handler.ts
+++ b/src/db/data/handler.ts
@@ -70,7 +70,10 @@ export const saveNoticeToDB = async (): Promise<void> => {
 
     const noticeLink = await noticeCrawling(college);
     const noticeLists = await noticeListCrawling(noticeLink);
-    if (noticeLists.normalNotice.length === 0) {
+    if (
+      noticeLists.normalNotice.length === 0 &&
+      noticeLists.pinnedNotice.length === 0
+    ) {
       notificationToSlack(`${noticeLink} 크롤링 실패`);
       continue;
     }

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -9,4 +9,5 @@ cron.schedule('0 2 * * *', async () => {
   const month = today.getMonth() + 1; // 월은 0부터 시작하므로 1을 더해줍니다.
   const day = today.getDate();
   notificationToSlack(`${year}-${month}-${day} 크롤링 완료`);
+  console.log(`${year}-${month}-${day} 크롤링 완료`);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,12 @@ import { initialCrawling } from 'src/hooks/startCrawlingData';
 import './hooks/cronNoticeCrawling';
 
 const app = express();
-app.use(morgan('dev'));
 app.use(cors(corsOptions));
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 app.use(express.json());
 app.use(errorHandler);
+
+if (process.env.NODE_ENV === 'development') app.use(morgan('dev'));
 
 initialCrawling();
 


### PR DESCRIPTION
## 🤠 개요

- closes: #86
- 공간정보시스템공학과 크롤링 안되는 문제를 해결했어요
- 불필요한 로그를 제거했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 공간정보시스템공학과 크롤링이 안됐던 이유
- 고정 공지사항과 일반 공지사항이 있는데 일반 공지사항이 크롤링된게 없을때 에러발생하도록 했는데 공간정보시스템 공지사항 첫 페이지에 고정공지사항밖에 없어서 에러가 발생했어요
- 고정 공지사항, 일반 공지사항 둘 다 크롤링된게 없는경우 에러가 발생하도록 수정했어요

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
