### PR TITLE
Feat: 캐러셀에 들어가는 웨일비 데이터는 모집기간이 남아있는 데이터 최대 7개로 제한

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -50,7 +50,16 @@ export const getWhalebe = async (): Promise<WhalebeData[]> => {
   return new Promise<WhalebeData[]>((resolve) => {
     db.query(query, (err, res) => {
       if (err) notificationToSlack('웨일비 조회 실패');
-      resolve(res as WhalebeData[]);
+      const whalebeData = res as WhalebeData[];
+      const today = new Date();
+      const todayString = `${today.getFullYear()}-${String(
+        today.getMonth() + 1,
+      ).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+      const filteredData = whalebeData
+        .filter((data) => data.date >= todayString)
+        .slice(0, 7);
+      resolve(filteredData);
     });
   });
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #110 
- 캐러셀에 들어가는 웨일비 데이터들 중 모집기간이 지난 데이터는 삭제하도록 했어요
- 그리고 데이터는 최대 7개로 최근 데이터7개로 선정했고 오래된 데이터는 삭제하도록 했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
