### PR TITLE
Fix/#112: push 알림 실패해도 나머지 인원들에게 알림 전송하도록 수정

### DIFF
--- a/src/apis/subscribe/service.ts
+++ b/src/apis/subscribe/service.ts
@@ -73,22 +73,23 @@ export const pushNotification = (major: string): Promise<number> => {
     db.query(query, async (err: Error, res: SubscribeUser[]) => {
       if (err) console.error(err);
 
-      try {
-        const message: PushMessage = {
-          title: `${major} 알림`,
-          body: '새로운 공지가 추가됐어요',
-          icon: './icons/icon-192x192.png',
-        };
+      const message: PushMessage = {
+        title: `${major} 알림`,
+        body: '새로운 공지가 추가됐어요',
+        icon: './icons/icon-192x192.png',
+      };
 
-        for (const userInfo of res) {
+      for (const userInfo of res) {
+        try {
           await webpush.sendNotification(
             JSON.parse(userInfo.user),
             JSON.stringify(message),
           );
+        } catch (error) {
+          notificationToSlack(error);
         }
         resolve(res.length);
-      } catch (error) {
-        notificationToSlack(error);
+
         resolve(0);
       }
     });

--- a/src/apis/subscribe/service.ts
+++ b/src/apis/subscribe/service.ts
@@ -87,6 +87,12 @@ export const pushNotification = (major: string): Promise<number> => {
           );
         } catch (error) {
           notificationToSlack(error);
+          const deleteQuery = `DELETE FROM ${major}구독 WHERE user = ?`;
+          db.query(deleteQuery, [userInfo.user], (deleteErr) => {
+            if (deleteErr)
+              notificationToSlack('알림 보낼 수 없는 토큰 삭제 실패');
+            else console.log('알림 보낼 수 없는 토큰 삭제');
+          });
         }
         resolve(res.length);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,5 +63,5 @@ const forDeployedServer = () => {
   });
 };
 
-saveWhalebeToDB();
+// saveWhalebeToDB();
 // forDeployedServer();


### PR DESCRIPTION
## 🤠 개요

- closes: #112 
-  push 알림 실패해도 나머지 인원들에게 알림 전송하도록 수정했어요
- push 알림을 실패한 토큰은 DB 에서 제거하도록 했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
