### PR TITLE
Feat/#118: 푸쉬 알림 전송 로직 변경

### DIFF
--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -1,5 +1,6 @@
 import { pushNotification } from '@apis/subscribe/service';
 import {
+  PushNoti,
   saveNoticeToDB,
   saveSchoolNoticeToDB,
   saveWhalebeToDB,
@@ -7,18 +8,17 @@ import {
 import cron from 'node-cron';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
-const pushToUsers = async (majors: string[]) => {
+const pushToUsers = async (pushNotiToUserLists: PushNoti) => {
   let pushedUserCount = ``;
-  for (const major of majors) {
-    const count = await pushNotification(major);
-    pushedUserCount += `${major} ${count}명 알림 완료\n`;
+  for (const key in pushNotiToUserLists) {
+    const count = await pushNotification(key, pushNotiToUserLists[key]);
+    pushedUserCount += `${key} ${count}명 알림 완료\n`;
   }
   notificationToSlack(pushedUserCount);
 };
 
 cron.schedule('0 0-9 * * 1-5', async () => {
-  const majors = await saveNoticeToDB();
-  await saveNoticeToDB();
+  const pushNotiToUserLists = await saveNoticeToDB();
   await saveSchoolNoticeToDB();
   await saveWhalebeToDB();
   const today = new Date();
@@ -27,5 +27,5 @@ cron.schedule('0 0-9 * * 1-5', async () => {
   const day = today.getDate();
   notificationToSlack(`${year}-${month}-${day} 크롤링 완료`);
   console.log(`${year}-${month}-${day} 크롤링 완료`);
-  pushToUsers(majors);
+  pushToUsers(pushNotiToUserLists);
 });


### PR DESCRIPTION
## 🤠 개요

- closes: #118 
- 만약 공지사항이 2개 올라오면 2번 push 알림을 보내도록 수정했어요
- 알림 전송 시 새로 올라온 공지사항의 제목이 보이도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
이런식으로 여러개 공지사항이 추가되면 여러개의 알림이 올거에요!
<img width="372" alt="image" src="https://github.com/GDSC-PKNU-21-22/pknu-notice-back/assets/71641127/e4f05992-482f-48dd-852d-4c972d1c2f88">
