### PR TITLE
Config: 도커로 실행되는 mysql에서 데이터를 마운트시키도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dist-ssr
 .flaskenv*
 !.env.project
 !.env.vault
+tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - --collation-server=utf8mb4_unicode_ci
     volumes:
       - ./sqls:/docker-entrypoint-initdb.d
+      - ./tmp:/var/lib/mysql
 
 networks:
   mysql_db:


### PR DESCRIPTION
## 🤠 개요

- closes: #123 
- 도커로 실행되는 mysql이 간헐적으로 컨테이너 내의 /var/lib/mysql 디렉토리에서 문제가 발생하여 동작하지 않는 문제가 있어요
- 이 문제를 해결하기 위해 /tmp 폴더와 컨테이너의 /var/lib/mysql 디렉토리를 마운트시켜 데이터를 관리하여 컨테이너가 정상적으로 동작하도록 구성해줬어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
