### PR TITLE
Fix: 유저에게 푸시알림 안가는 문제 해결

### DIFF
--- a/src/apis/subscribe/service.ts
+++ b/src/apis/subscribe/service.ts
@@ -76,6 +76,10 @@ export const pushNotification = (
     db.query(query, async (err: Error, res: SubscribeUser[]) => {
       if (err) console.error(err);
 
+      if (res.length === 0) {
+        resolve(0);
+        return;
+      }
       for (const userInfo of res) {
         for (const lists of noticeTitle) {
           try {
@@ -99,8 +103,6 @@ export const pushNotification = (
           }
         }
         resolve(res.length);
-
-        resolve(0);
       }
     });
   });


### PR DESCRIPTION
## 🤠 개요

- closes: #125 
- 유저에게 푸시알림 안가는 문제 해결했어요
- for 반복문에서 구독하는 유저가 0명인 경우 문제가 발생하기에 처리했어요
- 혹시 부림이를 사용하기 위해 리뷰없이 바로 배포까지 진행하도록 할게요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
