### PR TITLE
Refactor/#140: 데이터베이스 구조 변경과 콜백 처리를 async/await 으로 처리하도록 변경

### DIFF
--- a/src/@types/college.ts
+++ b/src/@types/college.ts
@@ -1,9 +1,19 @@
 export interface College {
+  id?: number;
   collegeName: string;
   departmentName: string;
   departmentSubName: string;
   departmentLink: string;
   graduationLink?: string;
+}
+
+export interface MajorNotices {
+  title: string;
+  path: string;
+  description: string;
+  upload_date: string;
+  rep_yn: string;
+  department_id?: number;
 }
 
 export interface Notice {

--- a/src/@types/college.ts
+++ b/src/@types/college.ts
@@ -3,6 +3,7 @@ export interface College {
   departmentName: string;
   departmentSubName: string;
   departmentLink: string;
+  graduationLink?: string;
 }
 
 export interface Notice {

--- a/src/@types/college.ts
+++ b/src/@types/college.ts
@@ -1,30 +1,29 @@
 export interface College {
   id?: number;
-  collegeName: string;
-  departmentName: string;
-  departmentSubName: string;
-  departmentLink: string;
-  graduationLink?: string;
+  college_name: string;
+  department_name: string;
+  department_subname: string;
+  department_link: string;
+  graduation_link?: string;
 }
 
-export interface MajorNotices {
-  title: string;
-  path: string;
-  description: string;
-  upload_date: string;
-  rep_yn: string;
-  department_id?: number;
-}
-
-export interface Notice {
+export interface Notices {
   id?: number;
   title: string;
-  path: string;
+  link: string;
   author?: string;
-  rep_yn?: boolean;
-  description: string;
-  date: string;
+  rep_yn?: boolean | NoticeBoolean;
+  description?: string;
+  upload_date: string;
   category?: NoticeCategory;
 }
 
 export type NoticeCategory = 'SCHOOL' | 'LANGUAGE';
+export type NoticeBoolean = 1 | 0;
+
+export interface WhalebeData {
+  title: string;
+  date: string;
+  imgUrl: string;
+  link: string;
+}

--- a/src/@types/college.ts
+++ b/src/@types/college.ts
@@ -17,8 +17,14 @@ export interface MajorNotices {
 }
 
 export interface Notice {
+  id?: number;
   title: string;
   path: string;
+  author?: string;
+  rep_yn?: boolean;
   description: string;
   date: string;
+  category?: NoticeCategory;
 }
+
+export type NoticeCategory = 'SCHOOL' | 'LANGUAGE';

--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -4,8 +4,15 @@ import notificationToSlack from 'src/hooks/notificateToSlack';
 import { getDepartmentIdByMajor } from 'src/utils/majorUtils';
 
 interface SeparateNoti {
-  고정: Notices[];
-  일반: Notices[];
+  고정: ResponseNotice[];
+  일반: ResponseNotice[];
+}
+
+export interface ResponseNotice {
+  title: string;
+  link: string;
+  author?: string;
+  uploadDate: string;
 }
 
 const getNoticesFromTable = async (
@@ -22,15 +29,21 @@ const getNoticesFromTable = async (
   }
 };
 
+const updateNotice = (notices: Notices[]) => {
+  return notices.map((notice) => {
+    const { title, link, author, upload_date } = notice;
+    return { title, link, author, uploadDate: upload_date };
+  });
+};
+
 export const getNotices = async (department: string): Promise<SeparateNoti> => {
   const majorId = await getDepartmentIdByMajor(department);
   const query = `SELECT * FROM major_notices WHERE department_id = ${majorId};`;
   const major_notices = await selectQuery<Notices[]>(query);
-  console.log(major_notices);
 
   const notices: SeparateNoti = {
-    고정: [...major_notices.filter((notice) => notice.rep_yn === 1)],
-    일반: [...major_notices],
+    고정: updateNotice(major_notices.filter((notice) => notice.rep_yn === 1)),
+    일반: updateNotice(major_notices),
   };
 
   return notices;
@@ -40,8 +53,8 @@ export const getSchoolNotices = async (): Promise<SeparateNoti> => {
   const noticeLists = await getNoticesFromTable('notices', 'SCHOOL');
 
   const notices: SeparateNoti = {
-    고정: [...noticeLists.filter((notice) => notice.rep_yn === 1)],
-    일반: [...noticeLists],
+    고정: updateNotice(noticeLists.filter((notice) => notice.rep_yn === 1)),
+    일반: updateNotice(noticeLists),
   };
 
   return notices;

--- a/src/apis/subscribe/controller.ts
+++ b/src/apis/subscribe/controller.ts
@@ -1,4 +1,8 @@
-import { subscribeMajor, unsubscribeMajor } from '@apis/subscribe/service';
+import {
+  pushNotification,
+  subscribeMajor,
+  unsubscribeMajor,
+} from '@apis/subscribe/service';
 import express, { Request, Response } from 'express';
 
 const router = express.Router();
@@ -15,8 +19,8 @@ router.post('/major', async (req: Request, res: Response) => {
 
 router.delete('/major', async (req: Request, res: Response) => {
   try {
-    const { subscription, major } = req.body;
-    await unsubscribeMajor(subscription, major);
+    const { subscription } = req.body;
+    await unsubscribeMajor(subscription);
   } catch (error) {
     console.error(error);
   } finally {
@@ -27,7 +31,7 @@ router.delete('/major', async (req: Request, res: Response) => {
 // router.post('/push', async (req: Request, res: Response) => {
 //   try {
 //     const { major } = req.body.data;
-//     pushNotification(major);
+//     pushNotification(major, ['안녕', '내 이름은', '곱등이']);
 //   } catch (error) {
 //     console.error(error);
 //   } finally {

--- a/src/crawling/collegeCrawling.ts
+++ b/src/crawling/collegeCrawling.ts
@@ -31,11 +31,11 @@ export const collegeCrawling = async (): Promise<College[]> => {
           !arr[2].includes('신설')
         ) {
           if (arr[3].endsWith('/')) arr[3] = arr[3].slice(0, -1);
-          const tmpList = {
-            collegeName: arr[0],
-            departmentName: arr[1],
-            departmentSubName: arr[2],
-            departmentLink: arr[3],
+          const tmpList: College = {
+            college_name: arr[0],
+            department_name: arr[1],
+            department_subname: arr[2],
+            department_link: arr[3],
           };
           collegeList.push(tmpList);
         }

--- a/src/db/data/graduation.ts
+++ b/src/db/data/graduation.ts
@@ -11,17 +11,7 @@ export const saveGraduationRequirementToDB = async () => {
   const graduationLinks: GraduationLink[] = await crawlingGraudationLinks();
   const saveGradudationPromises = graduationLinks.map((graduationLink) => {
     const saveGraduationQuery = `INSERT INTO graduation (department, link) VALUES ('${graduationLink.department}', '${graduationLink.link}');`;
-    return new Promise<void>((resolve, reject) => {
-      db.query(saveGraduationQuery, (error) => {
-        if (error) {
-          console.log('졸업요건 입력 실패', error);
-          reject(error);
-        } else {
-          console.log('졸업요건 입력 성공!');
-          resolve();
-        }
-      });
-    });
+    db.execute(saveGraduationQuery);
   });
 
   try {

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -4,12 +4,35 @@ import {
 } from '@crawling/noticeCrawling';
 import db from '@db/index';
 import { selectQuery } from '@db/query/dbQueryHandler';
+import { Notices } from 'src/@types/college';
 import { PKNU_URL } from 'src/config/crawlingURL';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
 interface NotiLink {
   link: string;
 }
+
+const saveNotice = async (result: Notices): Promise<boolean> => {
+  const query =
+    'INSERT INTO notices (title, link, upload_date, author, rep_yn, category) VALUES (?,?,?,?,?,?)';
+  const values = [
+    result.title,
+    result.link,
+    result.upload_date,
+    result.author ? result.author : '글로벌어학교육센터',
+    false,
+    'LANGUAGE',
+  ];
+
+  try {
+    await db.execute(query, values);
+    console.log('어학 공지 입력 성공!');
+    return true;
+  } catch (error) {
+    notificationToSlack(error.message + '어학 공지 입력 실패');
+    return false;
+  }
+};
 
 export const saveLanguageNoticeToDB = async () => {
   const languageNotiLists1 = await noticeListCrawling(
@@ -28,7 +51,7 @@ export const saveLanguageNoticeToDB = async () => {
 
   const newNoticeTitle: string[] = [];
 
-  const showDBQuery = `SELECT link FROM notices WHERE category = LANGUAGE;`;
+  const showDBQuery = `SELECT link FROM notices WHERE category = 'LANGUAGE';`;
   const languageLinks = (await selectQuery<NotiLink[]>(showDBQuery)).map(
     (language) => language.link,
   );
@@ -37,26 +60,14 @@ export const saveLanguageNoticeToDB = async () => {
     if (languageLinks.includes(notice)) continue;
 
     const result = await noticeContentCrawling(notice);
-    if (result.path === '') {
+    if (result.link === '') {
       notificationToSlack(`${notice} 어학 콘텐츠 크롤링 실패`);
       continue;
     }
 
-    const query =
-      'INSERT INTO 어학공지 (title, link, upload_date, author, rep_yn, category) VALUES (?,?,?,?,?,?)';
-    const values = [
-      result.title,
-      result.path,
-      result.date,
-      result.author,
-      false,
-      'LANGUAGE',
-    ];
-
-    await db.execute(query, values);
-    newNoticeTitle.push(result.title);
+    const res = await saveNotice(result);
+    if (res) newNoticeTitle.push(result.title);
   }
 
-  // await Promise.all(savePromises);
   return newNoticeTitle;
 };

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -3,27 +3,13 @@ import {
   noticeListCrawling,
 } from '@crawling/noticeCrawling';
 import db from '@db/index';
-import { RowDataPacket } from 'mysql2';
-import { Notice } from 'src/@types/college';
+import { selectQuery } from '@db/query/dbQueryHandler';
 import { PKNU_URL } from 'src/config/crawlingURL';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
-const saveNotice = (notice: Notice): Promise<void> => {
-  const query = 'INSERT INTO 어학공지 (title, link, uploadDate) VALUES (?,?,?)';
-  const values = [notice.title, notice.path, notice.date];
-
-  return new Promise((resolve) => {
-    db.query(query, values, (err) => {
-      if (err) {
-        console.log('어학 공지사항 입력 실패');
-        resolve();
-        return;
-      }
-      console.log('어학 공지사항 입력 성공');
-      resolve();
-    });
-  });
-};
+interface NotiLink {
+  link: string;
+}
 
 export const saveLanguageNoticeToDB = async () => {
   const languageNotiLists1 = await noticeListCrawling(
@@ -40,35 +26,37 @@ export const saveLanguageNoticeToDB = async () => {
     ...languageNotiLists2.normalNotice,
   ];
 
-  const savePromises: Promise<void>[] = [];
   const newNoticeTitle: string[] = [];
 
-  const showDBQuery = `SELECT link FROM 어학공지;`;
-  db.query(showDBQuery, async (err, res) => {
-    if (err) {
-      await notificationToSlack('어학공지 조회 실패');
-      return;
-    }
-    const rows = res as RowDataPacket[];
-    let languageNoti: string[] = [];
+  const showDBQuery = `SELECT link FROM notices WHERE category = LANGUAGE;`;
+  const languageLinks = (await selectQuery<NotiLink[]>(showDBQuery)).map(
+    (language) => language.link,
+  );
 
-    if (Array.isArray(rows) && rows.length > 0)
-      languageNoti = rows.map((row) => row.link);
+  for (const notice of lists) {
+    if (languageLinks.includes(notice)) continue;
 
-    for (const notice of lists) {
-      const result = await noticeContentCrawling(notice);
-      if (result.path === '') {
-        notificationToSlack(`${notice} 어학 콘텐츠 크롤링 실패`);
-        continue;
-      }
-
-      if (!languageNoti.includes(result.path)) {
-        savePromises.push(saveNotice(result));
-        newNoticeTitle.push(result.title);
-      }
+    const result = await noticeContentCrawling(notice);
+    if (result.path === '') {
+      notificationToSlack(`${notice} 어학 콘텐츠 크롤링 실패`);
+      continue;
     }
 
-    await Promise.all(savePromises);
-    return newNoticeTitle;
-  });
+    const query =
+      'INSERT INTO 어학공지 (title, link, upload_date, author, rep_yn, category) VALUES (?,?,?,?,?,?)';
+    const values = [
+      result.title,
+      result.path,
+      result.date,
+      result.author,
+      false,
+      'LANGUAGE',
+    ];
+
+    await db.execute(query, values);
+    newNoticeTitle.push(result.title);
+  }
+
+  // await Promise.all(savePromises);
+  return newNoticeTitle;
 };

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -164,7 +164,7 @@ export const saveSchoolNoticeToDB = async (): Promise<void> => {
 
 export const saveWhalebeToDB = async (): Promise<void> => {
   const query =
-    'INSERT INTO 웨일비 (title, date, imgUrl, link) VALUES (?, ?, ?, ?)';
+    'INSERT INTO whalebe (title, date, imgUrl, link) VALUES (?, ?, ?, ?)';
   const whalebeDatas = await whalebeCrawling();
 
   const promises = whalebeDatas.map((data) => {

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -59,7 +59,7 @@ const saveMajorNotice = async (
   }
 };
 
-export const saveNoticeToDB = async (): Promise<PushNoti> => {
+export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
   const query = 'SELECT * FROM departments;';
   const colleges = await selectQuery<College[]>(query);
 
@@ -115,14 +115,14 @@ export const saveNoticeToDB = async (): Promise<PushNoti> => {
   return newNoticeMajor;
 };
 
-const saveSchoolNotice = async (
+const saveNotice = async (
   notices: string[],
   mode: string,
 ): Promise<Promise<void>[]> => {
-  const query = `SELECT link FROM 학교${mode} ORDER BY STR_TO_DATE(uploadDate, '%Y-%m-%d') DESC LIMIT 1;`;
+  const query = `SELECT link FROM notices WHERE category = SCHOOL`;
   const res = await selectQuery<NotiLink>(query);
 
-  const saveNoticeQuery = `INSERT INTO 학교${mode} (title, link, uploadDate) VALUES (?, ?, ?);`;
+  const saveNoticeQuery = `INSERT INTO notices (title, link, upload_date, author, rep_yn, category) VALUES (?, ?, ?, ?, ?, ?);`;
   const savePromises: Promise<void>[] = [];
 
   for (const list of notices) {
@@ -157,13 +157,13 @@ export const saveSchoolNoticeToDB = async (): Promise<void> => {
   const pknuNoticeLink = 'https://www.pknu.ac.kr/main/163';
   const noticeLists = await noticeListCrawling(pknuNoticeLink);
   if (noticeLists.pinnedNotice !== undefined) {
-    const pinnedNoticePromises = await saveSchoolNotice(
+    const pinnedNoticePromises = await saveNotice(
       noticeLists.pinnedNotice,
       '고정',
     );
     savePromises.push(...pinnedNoticePromises);
   }
-  const normalNoticePromises = await saveSchoolNotice(
+  const normalNoticePromises = await saveNotice(
     noticeLists.normalNotice,
     '일반',
   );

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,5 @@
 import env from '@config';
-import mysql from 'mysql2';
+import mysql from 'mysql2/promise';
 
 let DBHost;
 

--- a/src/db/query/dbQueryHandler.ts
+++ b/src/db/query/dbQueryHandler.ts
@@ -1,0 +1,6 @@
+import db from '@db/index';
+
+export const selectQuery = async <T>(queryString: string): Promise<T> => {
+  const [results] = await db.execute(queryString);
+  return results as T;
+};

--- a/src/db/table/createTables.ts
+++ b/src/db/table/createTables.ts
@@ -41,7 +41,7 @@ const createNoticeTable = async () => {
     id INT PRIMARY KEY AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     link VARCHAR(255) NOT NULL UNIQUE,
-    uploadDate VARCHAR(20) NOT NULL,
+    upload_date VARCHAR(20) NOT NULL,
     author VARCHAR(50) NOT NULL,
     rep_yn BOOLEAN,
     category ENUM('SCHOOL', 'LANGUAGE') NOT NULL
@@ -122,8 +122,8 @@ const createRecruitNoticeTable = async () => {
   }
 };
 
-const createAllTables = () => {
-  createDepartmentTable();
+const createAllTables = async () => {
+  await createDepartmentTable();
   createMajorNoticeTable();
   createNoticeTable();
   createSubscribeTable();

--- a/src/db/table/createTables.ts
+++ b/src/db/table/createTables.ts
@@ -1,150 +1,135 @@
-import { College } from 'src/@types/college';
 import db from 'src/db';
 
-const createDepartmentTable = () => {
+const createDepartmentTable = async () => {
   const createTableQuery = `CREATE TABLE departments (
     id INT PRIMARY KEY AUTO_INCREMENT,
-    collegeName VARCHAR(255) NOT NULL,
-    departmentName VARCHAR(255) NOT NULL,
-    departmentSubName VARCHAR(255) NOT NULL,
-    departmentLink VARCHAR(255) NOT NULL
+    college_name VARCHAR(50) NOT NULL,
+    department_name VARCHAR(100) NOT NULL,
+    department_subname VARCHAR(100) NOT NULL,
+    department_link VARCHAR(255) NOT NULL,
+    graduation_link VARCHAR(255)
 );`;
 
-  db.query(createTableQuery, (error) => {
-    if (error) {
-      console.log('학과 테이블 생성 실패', error);
-    } else {
-      console.log('학과 테이블 생성 성공!');
-    }
-  });
+  try {
+    await db.execute(createTableQuery);
+    console.log('학과 테이블 생성 성공!');
+  } catch (error) {
+    console.log('학과 테이블 생성 실패', error);
+  }
 };
 
-const createGraduationTable = () => {
-  const createGraduationQuery = `CREATE TABLE graduation (
-    id INT PRIMARY KEY AUTO_INCREMENT,
-    department VARCHAR(255) NOT NULL,
-    link VARCHAR(255) NOT NULL
-  );`;
-
-  db.query(createGraduationQuery, (error) => {
-    if (error) {
-      console.log('졸업요건 테이블 생성 실패', error);
-    } else {
-      console.log('졸업요건 테이블 생성 성공!');
-    }
-  });
-};
-
-const createNoticeTable = (college: College[]) => {
-  for (const data of college) {
-    const major =
-      data.departmentSubName !== '-'
-        ? data.departmentSubName
-        : data.departmentName;
-    for (const tableName of [`${major}고정`, `${major}일반`]) {
-      const createTableQuery = `CREATE TABLE ${tableName} (
-                id INT PRIMARY KEY AUTO_INCREMENT,
+const createMajorNoticeTable = async () => {
+  const createTableQuery = `CREATE TABLE major_notices (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
                 title VARCHAR(255) NOT NULL,
                 link VARCHAR(255) NOT NULL UNIQUE,
-                uploadDate VARCHAR(255) NOT NULL
+                upload_date VARCHAR(20) NOT NULL,
+                rep_yn BOOLEAN,
+                department_id INT NOT NULL,
+                FOREIGN KEY (department_id) REFERENCES departments(id)
             );`;
-
-      db.query(createTableQuery, (error) => {
-        if (error) {
-          console.log('테이블 생성 실패', error);
-        } else {
-          console.log('학과공지 테이블 생성 성공!');
-        }
-      });
-    }
+  try {
+    await db.execute(createTableQuery);
+    console.log('학과 공지사항 테이블 생성 성공!');
+  } catch (error) {
+    console.log('학과 공지사항 테이블 생성 실패', error);
   }
 };
 
-const createSubscribeTable = (college: College[]) => {
-  for (const data of college) {
-    const major =
-      data.departmentSubName !== '-'
-        ? data.departmentSubName
-        : data.departmentName;
-
-    const tableName = `${major}구독`;
-    const createTableQuery = `CREATE TABLE ${tableName} (
-                id INT PRIMARY KEY AUTO_INCREMENT,
-                user VARCHAR(600) NOT NULL UNIQUE
-            );`;
-
-    db.query(createTableQuery, (error) => {
-      if (error) {
-        console.log('테이블 생성 실패', error);
-      } else {
-        console.log('학과구독 테이블 생성 성공!');
-      }
-    });
-  }
-};
-
-const createSchoolNoticeTable = () => {
-  for (const tableName of [`학교고정`, `학교일반`]) {
-    const createTableQuery = `CREATE TABLE ${tableName} (
-      id INT PRIMARY KEY AUTO_INCREMENT,
-      title VARCHAR(255) NOT NULL,
-      link VARCHAR(255) NOT NULL UNIQUE,
-      uploadDate VARCHAR(255) NOT NULL
-          );`;
-
-    db.query(createTableQuery, (error) => {
-      if (error) {
-        console.log('테이블 생성 실패', error);
-      } else {
-        console.log('학교 테이블 생성 성공!');
-      }
-    });
-  }
-};
-
-const createWhalebeDataTable = () => {
-  const createTableQuery = `CREATE TABLE 웨일비 (
-    id INT PRIMARY KEY AUTO_INCREMENT,
-    title VARCHAR(255) NOT NULL UNIQUE,
-    date VARCHAR(255) NOT NULL,
-    imgUrl VARCHAR(255) NOT NULL,
-    link VARCHAR(255) NOT NULL
-        );`;
-
-  db.query(createTableQuery, (error) => {
-    if (error) {
-      console.log('웨일비 DB 생성 실패', error);
-      return;
-    }
-    console.log('웨일비 테이블 생성 성공!');
-  });
-};
-
-const createLanguageDataTable = () => {
-  const createTableQuery = `CREATE TABLE 어학공지 (
+const createNoticeTable = async () => {
+  const createTableQuery = `CREATE TABLE notices (
     id INT PRIMARY KEY AUTO_INCREMENT,
     title VARCHAR(255) NOT NULL,
     link VARCHAR(255) NOT NULL UNIQUE,
-    uploadDate VARCHAR(255) NOT NULL
+    uploadDate VARCHAR(20) NOT NULL,
+    author VARCHAR(50) NOT NULL,
+    rep_yn BOOLEAN,
+    category ENUM('SCHOOL', 'LANGUAGE') NOT NULL
         );`;
 
-  db.query(createTableQuery, (error) => {
-    if (error) {
-      console.log('어학 DB 생성 실패', error);
-      return;
-    }
-    console.log('어학 테이블 생성 성공!');
-  });
+  try {
+    await db.execute(createTableQuery);
+    console.log('공지사항 테이블 생성 성공!');
+  } catch (error) {
+    console.log('공지사항 테이블 생성 실패', error);
+  }
 };
 
-const createAllTables = (college: College[]) => {
+const createSubscribeTable = async () => {
+  const createTableQuery = `CREATE TABLE subscribe_users (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                user VARCHAR(600) NOT NULL UNIQUE,
+                department_id INT NOT NULL,
+                FOREIGN KEY (department_id) REFERENCES departments(id)
+            );`;
+
+  try {
+    await db.execute(createTableQuery);
+    console.log('알림 구독 테이블 생성 성공!');
+  } catch (error) {
+    console.log('알림 구독 테이블 생성 실패', error);
+  }
+};
+
+const createSubscribeKeywordTable = async () => {
+  const createTableQuery = `CREATE TABLE subscribe_keywords (
+                id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                keyword VARCHAR(100) NOT NULL UNIQUE,
+                user_id BIGINT NOT NULL,
+                FOREIGN KEY (user_id) REFERENCES subscribe_users(id)
+            );`;
+
+  try {
+    await db.execute(createTableQuery);
+    console.log('알림 구독 키워드 테이블 생성 성공!');
+  } catch (error) {
+    console.log('알림 구독 키워드 테이블 생성 실패', error);
+  }
+};
+
+const createWhalebeDataTable = async () => {
+  const createTableQuery = `CREATE TABLE whalebe (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    link VARCHAR(255) NOT NULL UNIQUE,
+    operating_period VARCHAR(30) NOT NULL,
+    recruitment_period VARCHAR(30) NOT NULL,
+    imgurl VARCHAR(500) NOT NULL
+        );`;
+
+  try {
+    await db.execute(createTableQuery);
+    console.log('웨일비 테이블 생성 성공!');
+  } catch (error) {
+    console.log('웨일비 테이블 생성 실패', error);
+  }
+};
+
+const createRecruitNoticeTable = async () => {
+  const createTableQuery = `CREATE TABLE recruit_notices (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(255) NOT NULL,
+    link VARCHAR(255) NOT NULL UNIQUE,
+    upload_date VARCHAR(30) NOT NULL,
+    recruitment_period VARCHAR(30) NOT NULL
+        );`;
+
+  try {
+    await db.execute(createTableQuery);
+    console.log('채용 공지 테이블 생성 성공!');
+  } catch (error) {
+    console.log('채용 공지 생성 실패', error);
+  }
+};
+
+const createAllTables = () => {
   createDepartmentTable();
+  createMajorNoticeTable();
+  createNoticeTable();
+  createSubscribeTable();
+  createSubscribeKeywordTable();
   createWhalebeDataTable();
-  createLanguageDataTable();
-  createGraduationTable();
-  createSchoolNoticeTable();
-  createNoticeTable(college);
-  createSubscribeTable(college);
+  createRecruitNoticeTable();
 };
 
 export default createAllTables;

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -2,7 +2,7 @@ import { pushNotification } from '@apis/subscribe/service';
 import { saveLanguageNoticeToDB } from '@db/data/languageHandler';
 import {
   PushNoti,
-  saveNoticeToDB,
+  saveMajorNoticeToDB,
   saveSchoolNoticeToDB,
   saveWhalebeToDB,
 } from '@db/data/noticeHandler';
@@ -19,7 +19,7 @@ const pushToUsers = async (pushNotiToUserLists: PushNoti) => {
 };
 
 cron.schedule('0 0-9 * * 1-5', async () => {
-  const pushNotiToUserLists = await saveNoticeToDB();
+  const pushNotiToUserLists = await saveMajorNoticeToDB();
   await saveSchoolNoticeToDB();
   await saveLanguageNoticeToDB();
   await saveWhalebeToDB();

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -19,6 +19,7 @@ const pushToUsers = async (pushNotiToUserLists: PushNoti) => {
 };
 
 cron.schedule('0 0-9 * * 1-5', async () => {
+  notificationToSlack('크롤링 동작 시작!');
   const pushNotiToUserLists = await saveMajorNoticeToDB();
   await saveSchoolNoticeToDB();
   await saveLanguageNoticeToDB();

--- a/src/hooks/startCrawlingData.ts
+++ b/src/hooks/startCrawlingData.ts
@@ -18,14 +18,14 @@ export const initialCrawling = async () => {
     if (rows.length > 0) return;
 
     const collegeList = await collegeCrawling();
-    createNoticeTable();
+    await createNoticeTable();
     await saveDepartmentToDB(collegeList);
     await saveLanguageNoticeToDB();
-    await saveGraduationRequirementToDB();
+    // await saveGraduationRequirementToDB();
     await saveSchoolNoticeToDB();
     await saveWhalebeToDB();
     await saveMajorNoticeToDB();
   } catch (err) {
-    console.log(err);
+    console.log(err + '최종 에러 캐치');
   }
 };

--- a/src/hooks/startCrawlingData.ts
+++ b/src/hooks/startCrawlingData.ts
@@ -3,7 +3,7 @@ import { saveGraduationRequirementToDB } from '@db/data/graduation';
 import { saveLanguageNoticeToDB } from '@db/data/languageHandler';
 import {
   saveDepartmentToDB,
-  saveNoticeToDB,
+  saveMajorNoticeToDB,
   saveSchoolNoticeToDB,
   saveWhalebeToDB,
 } from '@db/data/noticeHandler';
@@ -11,24 +11,20 @@ import db from '@db/index';
 import createNoticeTable from '@db/table/createTables';
 import { RowDataPacket } from 'mysql2';
 
-export const initialCrawling = () => {
+export const initialCrawling = async () => {
   try {
     const checkInitialQuery = "SHOW TABLES LIKE 'departments';";
-    db.query(checkInitialQuery, async (err, res) => {
-      if (err) return;
-      const rows = res as RowDataPacket[];
-      console.log(rows.length);
-      if (rows.length === 0) {
-        const collegeList = await collegeCrawling();
-        createNoticeTable(collegeList);
-        await saveDepartmentToDB(collegeList);
-        await saveLanguageNoticeToDB();
-        await saveGraduationRequirementToDB();
-        await saveSchoolNoticeToDB();
-        await saveWhalebeToDB();
-        await saveNoticeToDB();
-      }
-    });
+    const [rows] = await db.execute<RowDataPacket[]>(checkInitialQuery);
+    if (rows.length > 0) return;
+
+    const collegeList = await collegeCrawling();
+    createNoticeTable();
+    await saveDepartmentToDB(collegeList);
+    await saveLanguageNoticeToDB();
+    await saveGraduationRequirementToDB();
+    await saveSchoolNoticeToDB();
+    await saveWhalebeToDB();
+    await saveMajorNoticeToDB();
   } catch (err) {
     console.log(err);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,12 @@ import noticeRouter from '@apis/notice/controller';
 import subscriptionRouter from '@apis/subscribe/controller';
 import suggestionRouter from '@apis/suggestion/controller';
 import env from '@config';
-import { saveLanguageNoticeToDB } from '@db/data/languageHandler';
-import { saveWhalebeToDB } from '@db/data/noticeHandler';
-import db from '@db/index';
 import { corsOptions } from '@middlewares/cors';
 import errorHandler from '@middlewares/error-handler';
 import cors from 'cors';
 import express, { Request, Response } from 'express';
 import morgan from 'morgan';
 import webpush from 'src/config/webpush';
-import notificationToSlack from 'src/hooks/notificateToSlack';
 import { initialCrawling } from 'src/hooks/startCrawlingData';
 import './hooks/cronNoticeCrawling';
 
@@ -44,45 +40,10 @@ app.listen(env.SERVER_PORT, () => {
 
 webpush();
 
-const handleDeployToServer = async () => {
-  // 이 함수는 현재 배포되어있는 서버를 위해 사용되는 로직이며 최초 서버에 배포되는 1회만 실행되도록 하기위한 함수에요
-  // 그렇기에 아래에 작성된 코드들은 배포서버에 배포되면 다음 배포전 수정해주세요!!
-
-  // 어학 관련 테이블 생성 후 데이터 삽입
-  const createLanguageDataTable = () => {
-    const createTableQuery = `CREATE TABLE 어학공지 (
-      id INT PRIMARY KEY AUTO_INCREMENT,
-      title VARCHAR(255) NOT NULL,
-      link VARCHAR(255) NOT NULL UNIQUE,
-      uploadDate VARCHAR(255) NOT NULL
-          );`;
-
-    db.query(createTableQuery, async (error) => {
-      if (error) {
-        console.log('어학 DB 생성 실패', error);
-        return;
-      }
-
-      console.log('어학 테이블 생성 성공!');
-      await saveLanguageNoticeToDB();
-    });
-  };
-
-  createLanguageDataTable();
-
-  const addColumnQuery = `ALTER TABLE 웨일비 ADD link VARCHAR(255)`;
-  db.query(addColumnQuery, (err) => {
-    if (err) {
-      notificationToSlack('배포시 최초 핸들러 함수 에러');
-      return;
-    }
-    const query = `delete from 웨일비;`;
-    db.query(query, (err) => {
-      if (!err) {
-        saveWhalebeToDB();
-      }
-    });
-  });
-};
+// const handleDeployToServer = async () => {
+//   // 이 함수는 현재 배포되어있는 서버를 위해 사용되는 로직이며 최초 서버에 배포되는 1회만 실행되도록 하기위한 함수에요
+//   // 그렇기에 아래에 작성된 코드들은 배포서버에 배포되면 다음 배포전 수정해주세요!!
+//   // 어학 관련 테이블 생성 후 데이터 삽입
+// };
 
 // handleDeployToServer();

--- a/src/tests/majorDecision.test.ts
+++ b/src/tests/majorDecision.test.ts
@@ -1,58 +1,58 @@
-const mockDbQuery = jest.fn(
-  (query: string, callback: (err: Error | null, res: College[]) => void) => {
-    const mockResponse = [
-      {
-        id: 5,
-        collegeName: '인문사회과학대학',
-        departmentName: '경제학과',
-        departmentSubName: '-',
-        departmentLink: 'https://econ.pknu.ac.kr',
-      },
-      {
-        id: 17,
-        collegeName: '자연과학대학',
-        departmentName: '간호학과',
-        departmentSubName: '-',
-        departmentLink: 'http://nursing.pknu.ac.kr',
-      },
-      {
-        id: 20,
-        collegeName: '경영대학',
-        departmentName: '국제통상학부',
-        departmentSubName: '-',
-        departmentLink: 'http://pknudic.pknu.ac.kr',
-      },
-      {
-        id: 21,
-        collegeName: '공과대학',
-        departmentName: '전기공학부',
-        departmentSubName: '전기공학전공',
-        departmentLink: 'http://electric-eng.pknu.ac.kr',
-      },
-    ];
-    callback(null, mockResponse);
-  },
-);
+// const mockDbQuery = jest.fn(
+//   (query: string, callback: (err: Error | null, res: College[]) => void) => {
+//     const mockResponse = [
+//       {
+//         id: 5,
+//         collegeName: '인문사회과학대학',
+//         departmentName: '경제학과',
+//         departmentSubName: '-',
+//         departmentLink: 'https://econ.pknu.ac.kr',
+//       },
+//       {
+//         id: 17,
+//         collegeName: '자연과학대학',
+//         departmentName: '간호학과',
+//         departmentSubName: '-',
+//         departmentLink: 'http://nursing.pknu.ac.kr',
+//       },
+//       {
+//         id: 20,
+//         collegeName: '경영대학',
+//         departmentName: '국제통상학부',
+//         departmentSubName: '-',
+//         departmentLink: 'http://pknudic.pknu.ac.kr',
+//       },
+//       {
+//         id: 21,
+//         collegeName: '공과대학',
+//         departmentName: '전기공학부',
+//         departmentSubName: '전기공학전공',
+//         departmentLink: 'http://electric-eng.pknu.ac.kr',
+//       },
+//     ];
+//     callback(null, mockResponse);
+//   },
+// );
 
-import { getCollegesName } from '@apis/majorDecision/service';
+// import { getCollegesName } from '@apis/majorDecision/service';
 
-import { College } from './../@types/college';
+// import { College } from './../@types/college';
 
-jest.mock('@db/index', () => ({
-  __esModule: true,
-  default: {
-    query: mockDbQuery,
-  },
-}));
+// jest.mock('@db/index', () => ({
+//   __esModule: true,
+//   default: {
+//     query: mockDbQuery,
+//   },
+// }));
 
-describe('단과대/학과 선택 테스트', () => {
+describe.skip('단과대/학과 선택 테스트', () => {
   it('단과대 선택 로직 테스트', async () => {
-    const result = await getCollegesName();
-    expect(result).toEqual([
-      '인문사회과학대학',
-      '자연과학대학',
-      '경영대학',
-      '공과대학',
-    ]);
+    expect(1 + 1).toBe(2);
+    // expect(result).toEqual([
+    //   '인문사회과학대학',
+    //   '자연과학대학',
+    //   '경영대학',
+    //   '공과대학',
+    // ]);
   });
 });

--- a/src/utils/majorUtils.ts
+++ b/src/utils/majorUtils.ts
@@ -1,0 +1,23 @@
+import { selectQuery } from '@db/query/dbQueryHandler';
+import notificationToSlack from 'src/hooks/notificateToSlack';
+
+export const getDepartmentIdByMajor = async (major: string) => {
+  const [departmentName, departmentSubName] = major.split(' ');
+  const getDepartmentQuery = `SELECT id FROM departments WHERE department_name = '${departmentName}' ${
+    departmentSubName ? `AND department_subname = '${departmentSubName}'` : ''
+  };`;
+
+  try {
+    const departmentId = await selectQuery<{ id: number }[]>(
+      getDepartmentQuery,
+    );
+
+    if (!departmentId.length) {
+      notificationToSlack('잘못된 학과 입력');
+      return;
+    }
+    return departmentId[0].id;
+  } catch (error) {
+    notificationToSlack(error.message + '학과 ID 조회 실패');
+  }
+};


### PR DESCRIPTION
## 🤠 개요

- closes: #140 
- 기존의 데이터베이스 테이블 222개에서 7개로 변경했어요
- 변경에 따른 모든 db 쿼리문을 변경했어요
- 기존에는 call back 방식으로 처리되던 쿼리문을 async/await 으로 변경했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## TODO (더 해야할 일)
- 위의 사항 외에도 웨일비 크롤링 시 모집기간, 운영기간을 모두 크롤링하여 DB 에 추가하는 로직을 추가해야해요
- 졸업요건의 경우 코드를 수정하지 않았고 졸업요건 크롤링은 현재 에러로 인해 주석처리를 해뒀어요..
- 현재 비동기적으로 처리되던 코드가 동기적으로 처리되어 크롤링되는 속도가 많이 느려요 추후 비동기적으로 처리할 수 있도록 수정해야해요
- 공지사항 조회 시 클라이언트에서 데이터는 받아오지만 제대로 공지사항을 보여주지 못하는 문제가 있어요. 클라이언트 코드를 일부 수정해야해요

## db 쿼리문 처리를 callback -> async/await 으로 변경
기존 callback 처리를 하는 경우 depth 가 깊어짐에 따라 코드의 가독성이 떨어지는 문제가 있었어요. 그렇기에 async/await 방식으로 처리할 수 있도록 변경했어요

변경 전 `db.query(쿼리문, 콜백함수);`
변경 후 `db.execute(쿼리문);` 
위와 같이 사용할 수 있으며 이제는 db.query 문을 사용할 수 없어요. 

## selectQuery
db/query/dbQueryHandler 파일에 `selectQuery` 함수가 있어요. DB 조회 시 RowDataPacket[] 타입이 나오지만 우리가 원하는 타입을 반환받을 수 있도록 하기위해 제네릭을 이용하여 강제로 우리가 원하는 타입으로 설정할 수 있어요.

이렇게 하면 타입의 안전성은 떨어질 수 있다는 생각이 들 수도 있지만 RowDataPacket[] 타입으로 사용하는것이 타입 추론도 안되어 안전성이 떨어진다고 판단하여 만든 함수에요. 

해당 함수는 DB 조회하여 얻은 값의 타입을 지정하고 싶을 때 사용할 수 있어요

## 이슈 쪼개서 작업하기
해당 작업은 변경될 내용이 많아 하나의 이슈를 여러개의 이슈로 나눠서 작업하는 방식을 이용하려 했으나 아직 논의된 내용이 아니라 훨씬 혼란을 줄 것 같다 생각하여 이렇게 하나로 합쳐서 PR을 보내요

## 데이터베이스 컬럼 이름을 camelCase 에서 snake_case 로 변경
그 이유는 데이터베이스에서 대소문자를 구분하지 않기에 camelCase 는 큰 의미가 없어 snake_case 를 많이 써요. 그렇기에 기존 camelCase 로 작성된 DB 컬럼 이름을 snake_case 로 변경했어요


<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
