### PR TITLE
Fix/#150: 주기적인 크롤링의 에러 핸들링 추가

### DIFF
--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -5,6 +5,7 @@ import {
 } from '@crawling/noticeCrawling';
 import { whalebeCrawling } from '@crawling/whalebeCrawling';
 import { selectQuery } from '@db/query/dbQueryHandler';
+import { PoolConnection } from 'mysql2/promise';
 import { College, Notices, NoticeCategory } from 'src/@types/college';
 import db from 'src/db';
 import notificationToSlack from 'src/hooks/notificateToSlack';
@@ -37,6 +38,7 @@ const saveMajorNotice = async (
   notice: Notices,
   departmentId: number,
   isPinned: boolean,
+  connection?: PoolConnection,
 ): Promise<void> => {
   const saveNoticeQuery =
     'INSERT INTO major_notices (title, link, upload_date, rep_yn, department_id) VALUES (?, ?, ?, ?, ?)';
@@ -49,7 +51,8 @@ const saveMajorNotice = async (
   ];
 
   try {
-    await db.execute(saveNoticeQuery, values);
+    if (connection) await connection.execute(saveNoticeQuery, values);
+    else await db.execute(saveNoticeQuery, values);
     console.log(`ID: ${departmentId} 공지사항 입력 성공`);
   } catch (error) {
     notificationToSlack(error.message + '공지사항 입력 실패');
@@ -82,20 +85,23 @@ const convertSpecificNoticeToPinnedNotice = async (
   }
 };
 
-export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
+export const saveMajorNoticeToDB = async (
+  connection?: PoolConnection,
+): Promise<PushNoti> => {
   await convertAllNoticeToNormalNotice('major_notices');
   const query = 'SELECT * FROM departments;';
-  const colleges = await selectQuery<College[]>(query);
+  const colleges = await selectQuery<College[]>(query, connection);
 
   const getNotiLinkQuery = `SELECT link FROM major_notices;`;
-  const noticeLinksInDB = (await selectQuery<NotiLink[]>(getNotiLinkQuery)).map(
-    (noticeLink) => noticeLink.link,
-  );
+  const noticeLinksInDB = (
+    await selectQuery<NotiLink[]>(getNotiLinkQuery, connection)
+  ).map((noticeLink) => noticeLink.link);
 
-  // const savePromises: Promise<void>[] = [];
+  const savePromises: Promise<void>[] = [];
   const newNoticeMajor: PushNoti = {};
 
   for (const college of colleges) {
+    console.log(college.id);
     const noticeLink = await noticeCrawling(college);
     const noticeLists = await noticeListCrawling(noticeLink);
 
@@ -117,7 +123,7 @@ export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
       if (noticeLinksInDB.includes(result.link)) continue;
       if (!newNoticeMajor[college.id]) newNoticeMajor[college.id] = [];
       newNoticeMajor[college.id].push(result.title);
-      await saveMajorNotice(result, college.id, false);
+      savePromises.push(saveMajorNotice(result, college.id, false, connection));
     }
 
     if (pinnedNotices) {
@@ -129,7 +135,9 @@ export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
         }
 
         if (!noticeLinksInDB.includes(result.link)) {
-          saveMajorNotice(result, college.id, true);
+          savePromises.push(
+            saveMajorNotice(result, college.id, true, connection),
+          );
           continue;
         }
         convertSpecificNoticeToPinnedNotice('major_notices', result.link);
@@ -137,7 +145,7 @@ export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
     }
   }
 
-  // await Promise.all(savePromises);
+  await Promise.all(savePromises);
   return newNoticeMajor;
 };
 

--- a/src/db/query/dbQueryHandler.ts
+++ b/src/db/query/dbQueryHandler.ts
@@ -5,8 +5,8 @@ export const selectQuery = async <T>(
   queryString: string,
   connection?: PoolConnection,
 ): Promise<T> => {
-  let results;
-  if (connection) [results] = await connection.execute(queryString);
-  else [results] = await db.execute(queryString);
+  const [results] = connection
+    ? await connection.execute(queryString)
+    : await db.execute(queryString);
   return results as T;
 };

--- a/src/db/query/dbQueryHandler.ts
+++ b/src/db/query/dbQueryHandler.ts
@@ -1,6 +1,12 @@
 import db from '@db/index';
+import { PoolConnection } from 'mysql2/promise';
 
-export const selectQuery = async <T>(queryString: string): Promise<T> => {
-  const [results] = await db.execute(queryString);
+export const selectQuery = async <T>(
+  queryString: string,
+  connection?: PoolConnection,
+): Promise<T> => {
+  let results;
+  if (connection) [results] = await connection.execute(queryString);
+  else [results] = await db.execute(queryString);
   return results as T;
 };

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -54,6 +54,6 @@ cron.schedule('0 0-9 * * 1-5', async () => {
   cronNoticeCrawling();
 });
 
-cron.schedule('0 0-9 * * 1-5', async () => {
+cron.schedule('30 3 * * 1-5', async () => {
   cronExtracurricularCrawling();
 });

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -6,6 +6,7 @@ import {
   saveSchoolNoticeToDB,
   saveWhalebeToDB,
 } from '@db/data/noticeHandler';
+import db from '@db/index';
 import cron from 'node-cron';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
@@ -13,22 +14,46 @@ const pushToUsers = async (pushNotiToUserLists: PushNoti) => {
   let pushedUserCount = ``;
   for (const key in pushNotiToUserLists) {
     const count = await pushNotification(key, pushNotiToUserLists[key]);
-    pushedUserCount += `${key} ${count}명 알림 완료\n`;
+    if (!count) continue;
+    pushedUserCount += `학과번호:${key}, ${count}명 알림 완료\n`;
   }
   if (pushedUserCount.length !== 0) notificationToSlack(pushedUserCount);
 };
 
+const cronNoticeCrawling = async () => {
+  const connection = await db.getConnection();
+  try {
+    connection.beginTransaction();
+    const pushNotiToUserLists = await saveMajorNoticeToDB();
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth() + 1; // 월은 0부터 시작하므로 1을 더해줍니다.
+    const day = today.getDate();
+    notificationToSlack(`${year}-${month}-${day} 크롤링 완료`);
+    pushToUsers(pushNotiToUserLists);
+    await connection.commit();
+  } catch (error) {
+    await connection.rollback();
+    notificationToSlack(error.message);
+    cronNoticeCrawling();
+  }
+};
+
+const cronExtracurricularCrawling = async () => {
+  try {
+    await saveSchoolNoticeToDB();
+    await saveLanguageNoticeToDB();
+    await saveWhalebeToDB();
+  } catch (error) {
+    notificationToSlack(error.message);
+    cronExtracurricularCrawling();
+  }
+};
+
 cron.schedule('0 0-9 * * 1-5', async () => {
-  notificationToSlack('크롤링 동작 시작!');
-  const pushNotiToUserLists = await saveMajorNoticeToDB();
-  await saveSchoolNoticeToDB();
-  await saveLanguageNoticeToDB();
-  await saveWhalebeToDB();
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = today.getMonth() + 1; // 월은 0부터 시작하므로 1을 더해줍니다.
-  const day = today.getDate();
-  notificationToSlack(`${year}-${month}-${day} 크롤링 완료`);
-  console.log(`${year}-${month}-${day} 크롤링 완료`);
-  pushToUsers(pushNotiToUserLists);
+  cronNoticeCrawling();
+});
+
+cron.schedule('0 0-9 * * 1-5', async () => {
+  cronExtracurricularCrawling();
 });

--- a/src/hooks/startCrawlingData.ts
+++ b/src/hooks/startCrawlingData.ts
@@ -22,8 +22,8 @@ export const initialCrawling = async () => {
     await saveDepartmentToDB(collegeList);
     await saveLanguageNoticeToDB();
     // await saveGraduationRequirementToDB();
-    await saveSchoolNoticeToDB();
-    await saveWhalebeToDB();
+    saveSchoolNoticeToDB();
+    saveWhalebeToDB();
     await saveMajorNoticeToDB();
   } catch (err) {
     console.log(err + '최종 에러 캐치');


### PR DESCRIPTION
## 🤠 개요

- closes: #150 
- 우선 학과 공지사항은 기존과 동일하게 평일 09-18시 사이 매 시간마다 크롤링하도록 했어요
- 나머지 웨일비, 학교, 어학공지는 평일 12시 30분에 한 번 크롤링하도록 했어요 (자주 공지가 올라오지 않기떄문에요)
- 만약 cron 으로 실행하는 함수에 에러가 발생하면 다시 처음부터 크롤링 하도록 추가했어요
- 공지사항 크롤링을 하나의 트랜잭션으로 처리할 수 있도록 했어요

<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 트랜잭션 처리를 한 이유
만약 공지사항을 DB에 저장하는 과정 중 에러가 발생하면 다시 함수를 실행하지만 에러가 발생하기 전까지 저장된 공지는 사용자에게 알림을 줄 수 없어요. 그렇기에 공지사항 핸들링을 하나의 트랜잭션으로 처리하여 제대로 수행되지 않으면 rollback 되도록 구성했어요.

initialCrawling() 에서 공지사항 핸들링에서는 트랜잭션으로 처리하지 않고, cronNoticeCrawling() 에서 트랜잭션으로 처리하도록 props 로 받는 connection을 옵셔널로 설정했어요.

## 트랜잭션 처리 방법
현재 DB는 connection이 아닌 pool 로 되어있어요. 자세한 내용은 [노션링크](https://burimi.notion.site/DB-bec8f788b88542a3aab8150cd2f9c49c?pvs=4) 에서 확인할 수 있어요.
현재 연결된 pool 에서 하나의 connection을 만들어 해당 connection의 트랜잭션을 만들어 처리합니다. 그렇기에 트랜잭션을 처리하기 위해서는 동일한 connection을 이용해야하기에 props 로 전달하여 해당 커넥션으로 쿼리문을 처리할 수 있도록 구성했어요

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
