### PR TITLE
Feat/#155: 공지사항 링크 관리하는 상수 추가, 공지사항 작성자 크롤링 추가

### DIFF
--- a/src/config/crawlingURL.ts
+++ b/src/config/crawlingURL.ts
@@ -1,4 +1,7 @@
 export const PKNU_URL = {
+  main_homepage_notice: 'https://www.pknu.ac.kr/main/163',
+  major_information_page: 'https://www.pknu.ac.kr/main/23',
+  whalebe_homepage: 'https://whalebe.pknu.ac.kr',
   language_notice_exchange_student:
     'https://www.pknu.ac.kr/main/163?pageIndex=1&bbsId=2&searchCondition=title&searchKeyword=교환학생&cd=',
   language_notice_language_traning:
@@ -8,4 +11,12 @@ export const PKNU_URL = {
   recruit_notice(pageIndex: number) {
     return `https://pknujob.pknu.ac.kr/main/37?pageIndex=${pageIndex}&bbsId=11&searchCondition=0&strDt=&endDt=&searchKeyword=`;
   },
+};
+
+export const MAJOR_URL = {
+  spatial_information_system_engineering_notice:
+    'http://geoinfo.pknu.ac.kr/05piazza/08.php',
+  biomedical_engineering_notice:
+    'http://bme.pknu.ac.kr/bbs/board.php?bo_table=notice',
+  visual_design_notice: 'https://visual.pknu.ac.kr/visual/3674',
 };

--- a/src/config/crawlingURL.ts
+++ b/src/config/crawlingURL.ts
@@ -1,10 +1,11 @@
 export const PKNU_URL = {
-  LANGUAGE_NOTICE_EXCHANGE_STUDENT:
+  language_notice_exchange_student:
     'https://www.pknu.ac.kr/main/163?pageIndex=1&bbsId=2&searchCondition=title&searchKeyword=교환학생&cd=',
-  LANGUAGE_NOTICE_LANGUAGE_TRANING:
+  language_notice_language_traning:
     'https://www.pknu.ac.kr/main/163?pageIndex=1&bbsId=2&searchCondition=title&searchKeyword=어학연수&cd=',
-  RECRUIT_NOTICE(pageIndex: number) {
+  recruit_notice_hostlink: 'https://pknujob.pknu.ac.kr/main/37',
+
+  recruit_notice(pageIndex: number) {
     return `https://pknujob.pknu.ac.kr/main/37?pageIndex=${pageIndex}&bbsId=11&searchCondition=0&strDt=&endDt=&searchKeyword=`;
   },
-  RECRUIT_NOTICE_HOSTLINK: 'https://pknujob.pknu.ac.kr/main/37',
 };

--- a/src/crawling/collegeCrawling.ts
+++ b/src/crawling/collegeCrawling.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { College } from 'src/@types/college';
+import { PKNU_URL } from 'src/config/crawlingURL';
 
 import { crawlingGraudationLinks } from './graduationRequirementsCrawling';
 
@@ -18,8 +19,7 @@ const getCollegeData = ($: cheerio.Root, row: cheerio.Element) => {
 };
 
 export const collegeCrawling = async (): Promise<College[]> => {
-  const pknuURL = 'https://www.pknu.ac.kr';
-  const response = await axios.get(pknuURL + '/main/23');
+  const response = await axios.get(PKNU_URL.major_information_page);
   const $ = cheerio.load(response.data);
   const collegeTable = $('#user-table');
   const rows = collegeTable.find('tr').toArray();

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -236,6 +236,15 @@ export const noticeContentCrawling = async (link: string): Promise<Notices> => {
       .first()
       .text()
       .trim();
+    const author = bdContTable
+      .find('tbody')
+      .first()
+      .find('tr')
+      .eq(1)
+      .find('td')
+      .eq(1)
+      .text()
+      .trim();
     const upload_date = bdContTable
       .find('tbody')
       .first()
@@ -246,7 +255,7 @@ export const noticeContentCrawling = async (link: string): Promise<Notices> => {
       .text()
       .trim();
     const description = bdContTable.find('div.bdvTxt_wrap').text().trim();
-    const notice: Notices = { title, link, upload_date, description };
+    const notice: Notices = { title, author, link, upload_date, description };
     return notice;
   }
 

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { College } from 'src/@types/college';
 import { Notices } from 'src/@types/college';
+import { MAJOR_URL } from 'src/config/crawlingURL';
 
 interface NoticeLists {
   pinnedNotice?: string[];
@@ -37,7 +38,7 @@ export const noticeCrawling = async (college: College): Promise<string> => {
   if (college.department_subname === '의공학전공') {
     protocol = 'http://';
   } else if (college.department_subname === '공간정보시스템공학전공')
-    return 'http://geoinfo.pknu.ac.kr/05piazza/08.php';
+    return MAJOR_URL.spatial_information_system_engineering_notice;
   const response = await axios.get(college.department_link);
   const hostLink = protocol + response.request._redirectable._options.hostname;
   const $ = cheerio.load(response.data);
@@ -74,10 +75,8 @@ export const noticeListCrawling = async (
   const pinnedNotice: string[] = [];
   const normalNotice: string[] = [];
 
-  if (link === 'http://geoinfo.pknu.ac.kr/05piazza/08.php') {
-    const noticePage2Link =
-      'http://geoinfo.pknu.ac.kr/05piazza/08.php?p=2&key=&keyword=&bbscode=cate0501&reCategory=';
-    const noticePage2Lists = await noticeListCrawling(noticePage2Link, link);
+  if (link === MAJOR_URL.spatial_information_system_engineering_notice) {
+    const noticePage2Lists = await noticeListCrawling(link);
     pinnedNotice.push(...noticePage2Lists.pinnedNotice);
     normalNotice.push(...noticePage2Lists.normalNotice);
   }
@@ -94,19 +93,21 @@ export const noticeListCrawling = async (
       .text()
       .match(/\d{4}[-.]\d{2}[-.]\d{2}/);
 
-    if (link.startsWith('http://geoinfo.pknu.ac.kr/05piazza/08.php')) {
+    if (
+      link.startsWith(MAJOR_URL.spatial_information_system_engineering_notice)
+    ) {
       // 공간정보시스템공학과
       if ($(element).find('td').first().text().trim() === '공지')
         pinnedNotice.push(tmpLink);
       else normalNotice.push(tmpLink);
       flag = false;
-    } else if (link === 'http://bme.pknu.ac.kr/bbs/board.php?bo_table=notice') {
+    } else if (link === MAJOR_URL.biomedical_engineering_notice) {
       // 의공학과
       if ($(element).find('.notice_icon').length > 0)
         pinnedNotice.push(tmpLink);
       else normalNotice.push(tmpLink);
       flag = false;
-    } else if (link === 'https://visual.pknu.ac.kr/visual/3674') {
+    } else if (link === MAJOR_URL.visual_design_notice) {
       pinnedNotice.push(tmpLink);
     } else {
       const dateMatch = findDate[0];

--- a/src/crawling/whalebeCrawling.ts
+++ b/src/crawling/whalebeCrawling.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { WhalebeData } from 'src/@types/college';
+import { PKNU_URL } from 'src/config/crawlingURL';
 
 const sliceURL = (link: string): string => {
   if (link.startsWith('location.href=')) {
@@ -12,7 +13,7 @@ const sliceURL = (link: string): string => {
 };
 
 export const whalebeCrawling = async (): Promise<WhalebeData[]> => {
-  const hostname = 'https://whalebe.pknu.ac.kr';
+  const hostname = PKNU_URL.whalebe_homepage;
   const whalebeLink = hostname + '/main';
   const whalebeData: WhalebeData[] = [];
 

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -36,11 +36,11 @@ const saveNotice = async (result: Notices): Promise<boolean> => {
 
 export const saveLanguageNoticeToDB = async () => {
   const languageNotiLists1 = await noticeListCrawling(
-    PKNU_URL.LANGUAGE_NOTICE_EXCHANGE_STUDENT,
+    PKNU_URL.language_notice_exchange_student,
     'https://www.pknu.ac.kr/main/163',
   );
   const languageNotiLists2 = await noticeListCrawling(
-    PKNU_URL.LANGUAGE_NOTICE_LANGUAGE_TRANING,
+    PKNU_URL.language_notice_language_traning,
     'https://www.pknu.ac.kr/main/163',
   );
 

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -37,11 +37,11 @@ const saveNotice = async (result: Notices): Promise<boolean> => {
 export const saveLanguageNoticeToDB = async () => {
   const languageNotiLists1 = await noticeListCrawling(
     PKNU_URL.language_notice_exchange_student,
-    'https://www.pknu.ac.kr/main/163',
+    PKNU_URL.main_homepage_notice,
   );
   const languageNotiLists2 = await noticeListCrawling(
     PKNU_URL.language_notice_language_traning,
-    'https://www.pknu.ac.kr/main/163',
+    PKNU_URL.main_homepage_notice,
   );
 
   const lists = [

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -7,6 +7,7 @@ import { whalebeCrawling } from '@crawling/whalebeCrawling';
 import { selectQuery } from '@db/query/dbQueryHandler';
 import { PoolConnection } from 'mysql2/promise';
 import { College, Notices, NoticeCategory } from 'src/@types/college';
+import { PKNU_URL } from 'src/config/crawlingURL';
 import db from 'src/db';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
@@ -179,9 +180,7 @@ export const saveSchoolNoticeToDB = async (): Promise<void> => {
     (schoolNotiLink) => schoolNotiLink.link,
   );
 
-  // const savePromises: Promise<void>[] = [];
-  const pknuNoticeLink = 'https://www.pknu.ac.kr/main/163';
-  const noticeLists = await noticeListCrawling(pknuNoticeLink);
+  const noticeLists = await noticeListCrawling(PKNU_URL.main_homepage_notice);
   const pinnedNotices = noticeLists.pinnedNotice;
   const normalNotices = noticeLists.normalNotice;
 
@@ -201,8 +200,6 @@ export const saveSchoolNoticeToDB = async (): Promise<void> => {
     const notice = await noticeContentCrawling(noticeLink);
     await saveNotice(notice, false, 'SCHOOL');
   }
-
-  // await Promise.all(savePromises);
 };
 
 export const saveWhalebeToDB = async (): Promise<void> => {

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -160,7 +160,7 @@ const saveNotice = async (
     notice.title,
     notice.link,
     notice.upload_date,
-    '부경대학교',
+    notice.author ? notice.author : '부경대학교',
     isPinned,
     category,
   ];

--- a/src/db/data/recruitHandler.ts
+++ b/src/db/data/recruitHandler.ts
@@ -38,8 +38,8 @@ export const recruitHandler = async () => {
 
   for (let pageIndex = 1; pageIndex <= maxPageIndex; pageIndex++) {
     const noticeLists = await noticeListCrawling(
-      PKNU_URL.RECRUIT_NOTICE(pageIndex),
-      PKNU_URL.RECRUIT_NOTICE_HOSTLINK,
+      PKNU_URL.recruit_notice(pageIndex),
+      PKNU_URL.recruit_notice_hostlink,
     );
     for (const noticeList of noticeLists.normalNotice) {
       if (recruitLinksInDB.includes(noticeList)) break;

--- a/src/hooks/startCrawlingData.ts
+++ b/src/hooks/startCrawlingData.ts
@@ -23,8 +23,8 @@ export const initialCrawling = async () => {
     await saveLanguageNoticeToDB();
     await recruitHandler();
     // await saveGraduationRequirementToDB();
-    saveSchoolNoticeToDB();
-    saveWhalebeToDB();
+    await saveSchoolNoticeToDB();
+    await saveWhalebeToDB();
     await saveMajorNoticeToDB();
   } catch (err) {
     console.log(err + '최종 에러 캐치');

--- a/src/tests/collegeCrawling.test.ts
+++ b/src/tests/collegeCrawling.test.ts
@@ -1,6 +1,0 @@
-import { collegeCrawling } from '@crawling/collegeCrawling';
-
-test.skip('단과대학 크롤링 테스트', async () => {
-  const collegeList = await collegeCrawling();
-  expect(collegeList).toHaveLength(10);
-});


### PR DESCRIPTION
## 🤠 개요

- closes: #155 
- 공지사항 링크를 모아서 관리하는 상수를 만들었어요
- 학교 공지사항, 어학 공지사항만 크롤링 후 작성자 (author)를 반환하도록 했어요
- 학교 공지사항과 어학 공지사항 DB 에는 author 컬럼이 있고, 클라이언트에 반환할때도 author 값도 같이 반환하도록 했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
- author (작성자)도 같이 반환하는 것을 확인할 수 있어요
![image](https://github.com/GDSC-PKNU-Official/pknu-notice-back/assets/71641127/c90f1bfc-5cd9-4aa6-ba9a-1c502bc0c90b)
