### PR TITLE
Fix/#157: 어학 공지사항 크롤링 시 발생하는 문제 해결

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -9,8 +9,8 @@ import notificationToSlack from 'src/hooks/notificateToSlack';
 import { getDepartmentIdByMajor } from 'src/utils/majorUtils';
 
 interface SeparateNoti {
-  고정: ResponseNotice[];
-  일반: ResponseNotice[];
+  고정: ResponseNotice[] | Notices[];
+  일반: ResponseNotice[] | Notices[];
 }
 
 export interface ResponseNotice {
@@ -88,9 +88,14 @@ export const getWhalebe = async (): Promise<WhalebeData[]> => {
   }
 };
 
-export const getLanguage = async (): Promise<Notices[]> => {
+export const getLanguage = async (): Promise<SeparateNoti> => {
   const languageNotices = await getNoticesFromTable('notices', 'LANGUAGE');
-  return languageNotices;
+  const notices: SeparateNoti = {
+    일반: updateNotice(languageNotices),
+    고정: [],
+  };
+
+  return notices;
 };
 
 export const getRecruit = async (): Promise<RecruitData[]> => {
@@ -101,6 +106,6 @@ export const getRecruit = async (): Promise<RecruitData[]> => {
       new Date(notice2.recruitment_period.split('~')[0]).getTime() -
       new Date(notice1.recruitment_period.split('~')[0]).getTime(),
   );
-  console.log(recruitNotices);
+
   return recruitNotices;
 };

--- a/src/constants/languageAuthor.ts
+++ b/src/constants/languageAuthor.ts
@@ -1,3 +1,3 @@
-const LANGUAGEAUTHOR = ['글로벌어학교육센터', '국제교류부'];
+const LANGUAGE_AUTHOR = ['글로벌어학교육센터', '국제교류부'];
 
-export default LANGUAGEAUTHOR;
+export default LANGUAGE_AUTHOR;

--- a/src/constants/languageAuthor.ts
+++ b/src/constants/languageAuthor.ts
@@ -1,0 +1,3 @@
+const LANGUAGEAUTHOR = ['글로벌어학교육센터', '국제교류부'];
+
+export default LANGUAGEAUTHOR;

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -6,7 +6,7 @@ import db from '@db/index';
 import { selectQuery } from '@db/query/dbQueryHandler';
 import { Notices } from 'src/@types/college';
 import { PKNU_URL } from 'src/config/crawlingURL';
-import LANGUAGEAUTHOR from 'src/constants/languageAuthor';
+import LANGUAGE_AUTHOR from 'src/constants/languageAuthor';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
 interface NotiLink {
@@ -25,7 +25,7 @@ const saveNotice = async (result: Notices): Promise<boolean> => {
     'LANGUAGE',
   ];
 
-  if (!LANGUAGEAUTHOR.includes(result.author)) return true;
+  if (!LANGUAGE_AUTHOR.includes(result.author)) return true;
 
   try {
     await db.execute(query, values);

--- a/src/db/data/languageHandler.ts
+++ b/src/db/data/languageHandler.ts
@@ -6,6 +6,7 @@ import db from '@db/index';
 import { selectQuery } from '@db/query/dbQueryHandler';
 import { Notices } from 'src/@types/college';
 import { PKNU_URL } from 'src/config/crawlingURL';
+import LANGUAGEAUTHOR from 'src/constants/languageAuthor';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
 interface NotiLink {
@@ -23,6 +24,8 @@ const saveNotice = async (result: Notices): Promise<boolean> => {
     false,
     'LANGUAGE',
   ];
+
+  if (!LANGUAGEAUTHOR.includes(result.author)) return true;
 
   try {
     await db.execute(query, values);
@@ -48,6 +51,11 @@ export const saveLanguageNoticeToDB = async () => {
     ...languageNotiLists1.normalNotice,
     ...languageNotiLists2.normalNotice,
   ];
+
+  if (languageNotiLists1.pinnedNotice)
+    lists.push(...languageNotiLists1.pinnedNotice);
+  if (languageNotiLists2.pinnedNotice)
+    lists.push(...languageNotiLists2.pinnedNotice);
 
   const newNoticeTitle: string[] = [];
 


### PR DESCRIPTION
## 🤠 개요

- closes: #157 
- 크롤링 시 발생하는 문제는 #157에서 확인할 수 있어요
- 어학 공지사항의 경우 공지 작성자가 "국제교류부", "글로벌어학교육센터" 가 아닌 경우 DB에 저장하지 않도록 하여 문제를 해결했어요
- 추가적으로 클라이언트에게 값을 전달할 때 클라이언트가 원하는 형식으로 포멧하여 전송하도록 했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
