### PR TITLE
Fix/#163: 공간정보시스템공학과 크롤링에 발생하는 문제 해결

### DIFF
--- a/src/config/crawlingURL.ts
+++ b/src/config/crawlingURL.ts
@@ -16,6 +16,10 @@ export const PKNU_URL = {
 export const MAJOR_URL = {
   spatial_information_system_engineering_notice:
     'http://geoinfo.pknu.ac.kr/05piazza/08.php',
+  spatial_information_system_engineering_notice2:
+    'http://geoinfo.pknu.ac.kr/05piazza/08.php?p=2&key=&keyword=&bbscode=cate0501&reCategory=',
+  spatial_information_system_engineering_notice3:
+    'http://geoinfo.pknu.ac.kr/05piazza/08.php?p=3&key=&keyword=&bbscode=cate0501&reCategory=',
   biomedical_engineering_notice:
     'http://bme.pknu.ac.kr/bbs/board.php?bo_table=notice',
   visual_design_notice: 'https://visual.pknu.ac.kr/visual/3674',

--- a/src/crawling/noticeCrawling.ts
+++ b/src/crawling/noticeCrawling.ts
@@ -76,9 +76,14 @@ export const noticeListCrawling = async (
   const normalNotice: string[] = [];
 
   if (link === MAJOR_URL.spatial_information_system_engineering_notice) {
-    const noticePage2Lists = await noticeListCrawling(link);
-    pinnedNotice.push(...noticePage2Lists.pinnedNotice);
-    normalNotice.push(...noticePage2Lists.normalNotice);
+    for (const spatialLink of [
+      MAJOR_URL.spatial_information_system_engineering_notice2,
+      MAJOR_URL.spatial_information_system_engineering_notice3,
+    ]) {
+      const noticePage2Lists = await noticeListCrawling(spatialLink, link);
+      pinnedNotice.push(...noticePage2Lists.pinnedNotice);
+      normalNotice.push(...noticePage2Lists.normalNotice);
+    }
   }
 
   tableData.each((index, element) => {


### PR DESCRIPTION
## 🤠 개요

- closes: #163 
- 공간정보시스템공학과 공지사항 2, 3페이지를 상수에 추가했어요
- 공간정보시스템공학과 크롤링 시 2, 3페이지 공지사항도 모두 같이 크롤링하도록 추가했어요

## 문제 발생 상황
#155 작업 도중 공간정보시스템공학과 크롤링할 때 추가로 2페이지를 크롤링하는게 아닌 추가로 1페이지 (기존 링크)로 크롤링하도록 하게하여 무한 루프에 빠져 Node 에서 사용할 수 있는 RAM 사용량을 초과한 문제가 있었어요. 
해당 작업으로 인해 배포 서버에 발생한 문제도 모두 해결할 수 있을거에요!
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
