### PR TITLE
Fix/#166: 채용 공지사항 데이터 반환 시 클라이언트가 필요로 하는 데이터를 반환하도록 수정

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -9,8 +9,8 @@ import notificationToSlack from 'src/hooks/notificateToSlack';
 import { getDepartmentIdByMajor } from 'src/utils/majorUtils';
 
 interface SeparateNoti {
-  고정: ResponseNotice[] | Notices[];
-  일반: ResponseNotice[] | Notices[];
+  고정: ResponseNotice[] | Notices[] | RecruitData[];
+  일반: ResponseNotice[] | Notices[] | RecruitData[];
 }
 
 export interface ResponseNotice {
@@ -98,7 +98,7 @@ export const getLanguage = async (): Promise<SeparateNoti> => {
   return notices;
 };
 
-export const getRecruit = async (): Promise<RecruitData[]> => {
+export const getRecruit = async (): Promise<SeparateNoti> => {
   const query = 'SELECT * FROM recruit_notices;';
   const recruitNotices = await selectQuery<RecruitData[]>(query);
   recruitNotices.sort(
@@ -106,6 +106,10 @@ export const getRecruit = async (): Promise<RecruitData[]> => {
       new Date(notice2.recruitment_period.split('~')[0]).getTime() -
       new Date(notice1.recruitment_period.split('~')[0]).getTime(),
   );
+  const notices: SeparateNoti = {
+    일반: recruitNotices,
+    고정: [],
+  };
 
-  return recruitNotices;
+  return notices;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,6 @@ const handleDeployToServer = async () => {
   // 이 함수는 현재 배포되어있는 서버를 위해 사용되는 로직이며 최초 서버에 배포되는 1회만 실행되도록 하기위한 함수에요
   // 그렇기에 아래에 작성된 코드들은 배포서버에 배포되면 다음 배포전 수정해주세요!!
   // 전공 관련 크롤링
-  await saveMajorNoticeToDB();
 };
 
-handleDeployToServer();
+// handleDeployToServer();


### PR DESCRIPTION
## 🤠 개요

- closes: #166
- 채용 공지사항 데이터 반환할때 클라이언트가 필요로 하는 데이터를 반환하도록 수정했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
