### PR TITLE
Fix/#169: 간헐적으로 서버에 발생하는 문제 해결

### DIFF
--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -208,7 +208,7 @@ export const saveWhalebeToDB = async (): Promise<void> => {
   const whalebeDatas = await whalebeCrawling();
 
   // TODO: 웨일비 크롤링하는 데이터 추가해야함
-  const promises = whalebeDatas.map((data) => {
+  const promises = whalebeDatas.map(async (data) => {
     const values = [
       data.title,
       data.link,
@@ -217,7 +217,12 @@ export const saveWhalebeToDB = async (): Promise<void> => {
       data.imgurl,
     ];
 
-    return db.execute(query, values);
+    try {
+      const result = await db.execute(query, values);
+      return result;
+    } catch (error) {
+      console.log(error.message);
+    }
   });
 
   Promise.all(promises);

--- a/src/hooks/notificateToSlack.ts
+++ b/src/hooks/notificateToSlack.ts
@@ -14,7 +14,8 @@ const notificationToSlack = async (text: string): Promise<void> => {
       text,
     });
   } catch (error) {
-    console.error(error);
+    console.error(error.message);
+    return notificationToSlack(text);
   }
   return;
 };


### PR DESCRIPTION
## 🤠 개요

- closes: #169 
- 슬랙 웹훅에서 에러 발생 시 다시 보내도록 수정
- 웨일비 데이터를 DB에 저장 시 에러 핸들링 추가

## 해당 작업을 한 이유
### 슬랙 웹훅에서 에러 발생 시 다시 보내도록 수정
한 번씩 슬랙 웹훅 전송에 에러가 발생하는 로그를 확인했어요. 한 번씩 발생하는 네트워크 문제로 인해 발생하는거 같은데 우리가 필요한 정보를 못받을 수 있기에 정상적으로 전송될때까지 계속 호출하도록 했어요

### 웨일비 데이터를 DB에 저장 시 에러 핸들링 추가
2024/01/09 서버가 꺼진 문제가 발생했어요. 문제를 확인해보니 웨일비 데이터를 DB에 저장할 때 Unqiue 로 설정된 컬럼에 동일한 값이 저장되다가 에러가 발생된거였어요. 웨일비 데이터를 DB에 저장할 때 에러핸들링이 안되어 있어서 서버가 꺼져있었어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
