### PR TITLE
Fix/#172: 학과 공지사항 핸들링 에러 수정

### DIFF
--- a/src/apis/notice/service.ts
+++ b/src/apis/notice/service.ts
@@ -43,7 +43,7 @@ const updateNotice = (notices: Notices[]) => {
 
 export const getNotices = async (department: string): Promise<SeparateNoti> => {
   const majorId = await getDepartmentIdByMajor(department);
-  const query = `SELECT * FROM major_notices WHERE department_id = ${majorId};`;
+  const query = `SELECT * FROM major_notices WHERE department_id = ${majorId} ORDER BY STR_TO_DATE(upload_date, '%Y-%m-%d') DESC;`;
   const major_notices = await selectQuery<Notices[]>(query);
 
   const notices: SeparateNoti = {

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -62,11 +62,13 @@ const saveMajorNotice = async (
 
 const convertAllNoticeToNormalNotice = async (
   tableName: string,
+  connection?: PoolConnection,
 ): Promise<void> => {
   const query = `UPDATE ${tableName} SET rep_yn = false;`;
 
   try {
-    await db.execute(query);
+    if (connection) await connection.execute(query);
+    else await db.execute(query);
     console.log('모든 공지를 일반 공지로 변경');
   } catch (error) {
     notificationToSlack(error.message + '\n모든 공지를 일반 공지로 변경 실패');
@@ -89,7 +91,7 @@ const convertSpecificNoticeToPinnedNotice = async (
 export const saveMajorNoticeToDB = async (
   connection?: PoolConnection,
 ): Promise<PushNoti> => {
-  await convertAllNoticeToNormalNotice('major_notices');
+  await convertAllNoticeToNormalNotice('major_notices', connection);
   const query = 'SELECT * FROM departments;';
   const colleges = await selectQuery<College[]>(query, connection);
 


### PR DESCRIPTION
## 🤠 개요

- closes: #172 
- 학과 공지사항 크롤링 시 connection 이 있다면 트랜잭션으로 처리되도록 수정
- http 요청으로 학과 공지사항을 DB에서 꺼낼 때 날짜 순서대로 꺼내서 반환하도록 수정
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
