### PR TITLE
Fix/#176: 슬랙 무한 알림 문제 해결

### DIFF
--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -27,7 +27,6 @@ export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
       await db.execute(saveCollegeQuery);
       console.log('단과대 입력 성공!');
     } catch (error) {
-      console.log(error.message, data);
       await notificationToSlack(`DB에 학과 삽입 실패`);
     }
   });
@@ -119,7 +118,7 @@ export const saveMajorNoticeToDB = async (
     for (const notice of normalNotices) {
       const result = await noticeContentCrawling(notice);
       if (result.link === '') {
-        notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+        // notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
         continue;
       }
 

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -83,7 +83,8 @@ const convertSpecificNoticeToPinnedNotice = async (
   try {
     await db.execute(query);
   } catch (error) {
-    notificationToSlack(error.message + '\n 고정 공지로 변경 실패');
+    console.log(error.message + '고정 공지로 변경 실패');
+    // notificationToSlack(error.message + '\n 고정 공지로 변경 실패');
   }
 };
 

--- a/src/hooks/cronNoticeCrawling.ts
+++ b/src/hooks/cronNoticeCrawling.ts
@@ -53,7 +53,7 @@ const cronExtracurricularCrawling = async () => {
   }
 };
 
-cron.schedule('0 0-9 * * 1-5', async () => {
+cron.schedule('0 0-9/2 * * 1-5', async () => {
   cronNoticeCrawling();
 });
 

--- a/src/utils/majorUtils.ts
+++ b/src/utils/majorUtils.ts
@@ -13,7 +13,7 @@ export const getDepartmentIdByMajor = async (major: string) => {
     );
 
     if (!departmentId.length) {
-      notificationToSlack('잘못된 학과 입력');
+      notificationToSlack(major + '잘못된 학과 입력');
       return;
     }
     return departmentId[0].id;


### PR DESCRIPTION
## 🤠 개요

- closes: #176 
- 학과 공지사항 크롤링을 09 ~ 18시 사이 2시간에 한 번씩 크롤링하도록 수정했어요 (9, 11, 13, 15, 17)
- 불필요한 슬랙 알림을 제거했어요

## 문제상황
### 무한 슬랙 알림이 왔던 이유
저번 PR 작업에서 모든 학과 공지사항을 일반 공지사항으로 바꾸는 로직도 transaction 으로 처리되도록 하였는데 이전 트랜잭션이 끝나기 전 새로운 트랜잭션을 열어서 생기는 문제였어요

제가 예상하는 정확한 문제는 하루종일 트랜잭션 처리가 실패였었기에 한 번 transaction 이 제대로 반환되지 않아서 지속적으로 문제가 발생했던거 같아요

추가적으로 현재 크롤링 동작이 20분동안 지속되는데 1시간마다 크롤링을 지속하면 비슷한 문제가 발생할거 같아 2시간에 한 번씩 크롤링을 하도록 변경했어요. 해당 사항은 크롤링 비동기처리를 제대로 처리가 되면 다시 1시간으로 롤백하는게 좋을거 같아요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
