### PR TITLE
fix(majorUtils getDepartmentIdByMajor): 특정 학과의 경우 공지사항 조회 및 알림설정이 불가했던 문제 해결

### DIFF
--- a/src/utils/majorUtils.ts
+++ b/src/utils/majorUtils.ts
@@ -2,10 +2,7 @@ import { selectQuery } from '@db/query/dbQueryHandler';
 import notificationToSlack from 'src/hooks/notificateToSlack';
 
 export const getDepartmentIdByMajor = async (major: string) => {
-  const [departmentName, departmentSubName] = major.split(' ');
-  const getDepartmentQuery = `SELECT id FROM departments WHERE department_name = '${departmentName}' ${
-    departmentSubName ? `AND department_subname = '${departmentSubName}'` : ''
-  };`;
+  const getDepartmentQuery = `SELECT id FROM departments WHERE department_name = '${major}' OR department_subname = '${major}'`;
 
   try {
     const departmentId = await selectQuery<{ id: number }[]>(


### PR DESCRIPTION
## 🤠 개요

- closes: #181 
- 더 유연하게 학과 ID 값을 구할 수 있도록 수정하여 해결했어요
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 문제 발생원인
<img width="460" alt="image" src="https://github.com/GDSC-PKNU-Official/pknu-notice-back/assets/71641127/2a2ce23e-3c59-46bb-a4fb-9c79f70eb394">
해당 학과로 가정한다면 `스마트헬스케어학부 해양스포츠전공` 이지만 길이가 너무 길어 `해양스포츠전공`으로 로컬 스토리지 저장되도록 되어있었어요

하지만 서버의 경우 `스마트헬스케어학부 해양스포츠전공` 값 전체를 받아야 처리할 수 있었던 문제가 있었기에 `해양스포츠전공` 만 받아도 처리될 수 있도록 수정했어요
<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
