### PR TITLE
Fix/#182: 공지사항 크롤링 비동기처리 추가 및 무한 슬랙알림 문제 해결

### DIFF
--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -184,6 +184,11 @@ export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
   });
 
   await Promise.all(savePromises);
+  if (failedMajor.length !== 0) {
+    const failedMajorList = failedMajor.join();
+    notificationToSlack('크롤링 실패한 학과: ' + failedMajorList);
+  }
+
   return newNoticeMajor;
 };
 

--- a/src/db/data/noticeHandler.ts
+++ b/src/db/data/noticeHandler.ts
@@ -17,6 +17,7 @@ export interface PushNoti {
 
 interface NotiLink {
   link: string;
+  rep_yn: boolean;
 }
 
 export const saveDepartmentToDB = async (college: College[]): Promise<void> => {
@@ -74,79 +75,113 @@ const convertAllNoticeToNormalNotice = async (
   }
 };
 
-const convertSpecificNoticeToPinnedNotice = async (
+const convertSpecificNoticePinned = async (
   tableName: string,
   noticeLink: string,
+  isPinned: boolean,
+  connection?: PoolConnection,
 ): Promise<void> => {
-  const query = `UPDATE ${tableName} SET rep_yn = true WHERE link = '${noticeLink}';`;
+  const query = `UPDATE ${tableName} SET rep_yn = ${isPinned} WHERE link = '${noticeLink}';`;
 
   try {
-    await db.execute(query);
+    if (connection) await connection.execute(query);
+    else await db.execute(query);
   } catch (error) {
     console.log(error.message + '고정 공지로 변경 실패');
     // notificationToSlack(error.message + '\n 고정 공지로 변경 실패');
   }
 };
 
-export const saveMajorNoticeToDB = async (
-  connection?: PoolConnection,
-): Promise<PushNoti> => {
-  await convertAllNoticeToNormalNotice('major_notices', connection);
+export const saveMajorNoticeToDB = async (): Promise<PushNoti> => {
+  // await convertAllNoticeToNormalNotice('major_notices', connection);
   const query = 'SELECT * FROM departments;';
-  const colleges = await selectQuery<College[]>(query, connection);
+  const colleges = await selectQuery<College[]>(query);
 
-  const getNotiLinkQuery = `SELECT link FROM major_notices;`;
-  const noticeLinksInDB = (
-    await selectQuery<NotiLink[]>(getNotiLinkQuery, connection)
-  ).map((noticeLink) => noticeLink.link);
-
-  const savePromises: Promise<void>[] = [];
   const newNoticeMajor: PushNoti = {};
+  const failedMajor: number[] = [];
 
-  for (const college of colleges) {
-    console.log(college.id);
-    const noticeLink = await noticeCrawling(college);
-    const noticeLists = await noticeListCrawling(noticeLink);
+  const savePromises = colleges.map(async (college) => {
+    const connection = await db.getConnection();
+    await connection.beginTransaction();
+    try {
+      console.log(college.id);
+      const noticeLink = await noticeCrawling(college);
+      const noticeLists = await noticeListCrawling(noticeLink);
+      const normalNotices = noticeLists.normalNotice;
+      const pinnedNotices = noticeLists.pinnedNotice;
+      const getNotiLinkQuery = `SELECT link, rep_yn FROM major_notices WHERE department_id = '${college.id}'`;
+      const noticeDataInDB = await selectQuery<NotiLink[]>(
+        getNotiLinkQuery,
+        connection,
+      );
+      const noticeLinksInDB = noticeDataInDB.map((noti) => noti.link);
+      const pinnedNoticeLinksInDB = noticeDataInDB
+        .filter((noti) => noti.rep_yn === true)
+        .map((noti) => noti.link);
 
-    const normalNotices = noticeLists.normalNotice;
-    const pinnedNotices = noticeLists.pinnedNotice;
-
-    if (normalNotices.length === 0) {
-      notificationToSlack(`${noticeLink} 크롤링 실패`);
-      continue;
-    }
-
-    for (const notice of normalNotices) {
-      const result = await noticeContentCrawling(notice);
-      if (result.link === '') {
-        // notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
-        continue;
+      if (normalNotices.length === 0) {
+        notificationToSlack(`${noticeLink} 크롤링 실패`);
+        connection.release();
+        return;
       }
 
-      if (noticeLinksInDB.includes(result.link)) continue;
-      if (!newNoticeMajor[college.id]) newNoticeMajor[college.id] = [];
-      newNoticeMajor[college.id].push(result.title);
-      savePromises.push(saveMajorNotice(result, college.id, false, connection));
-    }
-
-    if (pinnedNotices) {
-      for (const notice of pinnedNotices) {
+      for (const notice of normalNotices) {
         const result = await noticeContentCrawling(notice);
         if (result.link === '') {
-          notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+          // notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
           continue;
         }
 
-        if (!noticeLinksInDB.includes(result.link)) {
-          savePromises.push(
-            saveMajorNotice(result, college.id, true, connection),
-          );
-          continue;
-        }
-        convertSpecificNoticeToPinnedNotice('major_notices', result.link);
+        if (noticeLinksInDB.includes(result.link)) return;
+        if (!newNoticeMajor[college.id]) newNoticeMajor[college.id] = [];
+        newNoticeMajor[college.id].push(result.title);
+        saveMajorNotice(result, college.id, false, connection);
+        noticeLinksInDB.push(result.link);
       }
+
+      if (pinnedNotices) {
+        await pinnedNoticeLinksInDB
+          .filter((noti) => !pinnedNotices.includes(noti))
+          .map(
+            async (noti) =>
+              await convertSpecificNoticePinned(
+                'major_notices',
+                noti,
+                false,
+                connection,
+              ),
+          );
+        for (const notice of pinnedNotices) {
+          const result = await noticeContentCrawling(notice);
+          if (result.link === '') {
+            notificationToSlack(`${notice} 콘텐츠 크롤링 실패`);
+            continue;
+          }
+
+          if (!noticeLinksInDB.includes(result.link)) {
+            saveMajorNotice(result, college.id, true, connection);
+            continue;
+          }
+
+          if (!pinnedNoticeLinksInDB.includes(result.link))
+            convertSpecificNoticePinned(
+              'major_notices',
+              result.link,
+              true,
+              connection,
+            );
+        }
+      }
+
+      connection.commit();
+    } catch (error) {
+      notificationToSlack(college.id + '크롤링 실패' + error.message);
+      failedMajor.push(college.id);
+      connection.rollback();
+    } finally {
+      connection.release();
     }
-  }
+  });
 
   await Promise.all(savePromises);
   return newNoticeMajor;
@@ -188,7 +223,7 @@ export const saveSchoolNoticeToDB = async (): Promise<void> => {
 
   for (const noticeLink of pinnedNotices) {
     if (schoolNoticeLinksInDB.includes(noticeLink)) {
-      await convertSpecificNoticeToPinnedNotice('notices', noticeLink);
+      await convertSpecificNoticePinned('notices', noticeLink, true);
       continue;
     }
 


### PR DESCRIPTION
## 🤠 개요

- closes: #182 
- 크론 동작 시 3회 이상 계속 에러가 발생 시 재귀를 호출하지 않고 반환하도록 수정
- 공지사항 크롤링을 for -> map 으로 변경하여 비동기처리가 되도록 수정 및 리팩토링
- 트랜잭션 범위를 함수 전체에서 각 학과별 하나의 트랜잭션으로 동작하도록 추가 (트랜잭션 단위 축소)
- 고정 공지사항을 처리하는 로직 변경
<!--

- 이슈번호
- 한줄 설명

-->

## 💫 설명
## 크론 동작 시 3회 이상 계속 에러가 발생 시 재귀를 호출하지 않고 반환하도록 수정
기존에는 cron 함수 동작 시 예기치 못한 에러가 발생하면 성공할때 까지 재귀하도록 설정해뒀어요. 하지만 이전에 재귀를 하면서 문제를 해결하지 못해 결국 무한 루프에 돌게되는 문제가 발생하면서 무한 슬랙알림을 받게되는 문제가 있었어요.
그렇기에 cron 함수의 경우 최대 3회 재귀를 동작한 후 그래도 에러가 발생한다면 해당 함수는 return 하게 하여 무한 루프가 동작하지 않도록 했어요!

## 공지사항을 비동기처리로 처리
#34 에서 처리했던 학과 공지사항 핸들링을 비동기로 처리한것과 비슷해요
기존 20분 가량 걸리던 학과 공지사항 크롤링을 비동기 처리를 통해 4분 이내에 처리되도록 개선했어요

## 트랜잭션 범위 축소
트랜잭션의 단위는 작을수록 좋은걸로 들었어요 그 이유는 쿼리문 결과를 바로 데이터베이스에 적용되지 않고 메모리에 저장하고 있다가 commit 시에 한 번에 동작하기에 트랜잭션에 많은 로직이 들어있을수록 RAM 사용량이 커지게 되고 서버와 DB에게 좋지 않은 영향을 끼쳐요

그렇기에 트랜잭션의 단위를 각 학과별로 뒀어요. 그렇기에 학과별 트랜잭션을 만들어 문제가 생기면 해당 학과만 크롤링 반영이 되지 않도록 했어요

## 고정 공지사항 처리 로직 변경
이전에는 모든 학과 공지사항을 일괄적으로 일반 공지사항으로 변경한 뒤 고정 공지사항인 경우 rep_yn 을 true 로 업데이트해주는 방식이었어요. 하지만 이렇게 동작하다보니 고정 공지사항에 대해 제대로 처리되지 못한 학과는 고정 공지사항이 없어지는 문제가 있기에 로직을 개선했어요

DB에 저장된 고정 공지사항이 크롤링된 고정 공지사항에 존재하지 않는다 -> 해당 DB에 저장된 공지의 rep_yn = false 로 바꿔 일반 공지로 변경
크롤링된 고정 공지사항이 DB에는 일반 공지로 저장되어 있다 -> 해당 DB에 저장된 공지의 rep_yn = true 로 바꿔 고정 공지로 변경

<!--

- 현재 Pr 설명

-->

## 📷 스크린샷 (Optional)
